### PR TITLE
chore: fix pnpm workspace demo builds

### DIFF
--- a/demos/ai-chat/pnpm-workspace.yaml
+++ b/demos/ai-chat/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/demos/blog/pnpm-workspace.yaml
+++ b/demos/blog/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/demos/cms/pnpm-workspace.yaml
+++ b/demos/cms/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/demos/form-builder/pnpm-workspace.yaml
+++ b/demos/form-builder/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/demos/kanban/pnpm-workspace.yaml
+++ b/demos/kanban/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/demos/ui-builder/pnpm-workspace.yaml
+++ b/demos/ui-builder/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates `pnpm-workspace.yaml` files for demo apps; affects dependency/workspace resolution but not runtime code.
> 
> **Overview**
> Adds a `packages: - .` entry to each demo’s `pnpm-workspace.yaml` (`ai-chat`, `blog`, `cms`, `form-builder`, `kanban`, `ui-builder`) so pnpm includes the demo itself as a workspace package during installs/builds.
> 
> No code changes; only workspace configuration is adjusted while keeping `ignoredBuiltDependencies` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd8dd709cedf5fcf90c2ce22641a55ea399af1a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->