### PR TITLE
chore: update demos to version 2.5.1

### DIFF
--- a/demos/ai-chat/package.json
+++ b/demos/ai-chat/package.json
@@ -11,7 +11,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/demos/blog/package.json
+++ b/demos/blog/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/demos/cms/package.json
+++ b/demos/cms/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/demos/form-builder/package.json
+++ b/demos/form-builder/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/demos/kanban/package.json
+++ b/demos/kanban/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/demos/ui-builder/package.json
+++ b/demos/ui-builder/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
     "@btst/adapter-memory": "^2.0.3",
-    "@btst/stack": "^2.5.0",
+    "@btst/stack": "^2.5.1",
     "@btst/yar": "^1.2.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -21,6 +21,11 @@
       "plugins/route-docs",
       "plugins/better-auth-ui",
       "plugins/development",
+      "---[Database]Databases---",
+      "databases/adapters",
+      "---[BookOpenCheck]Concepts---",
+      "cli",
+      "api-reference",
       "---[Play]Demos---",
       "demos/index",
       "demos/blog",
@@ -28,12 +33,7 @@
       "demos/cms",
       "demos/form-builder",
       "demos/kanban",
-      "demos/ui-builder",
-      "---[Database]Databases---",
-      "databases/adapters",
-      "---[BookOpenCheck]Concepts---",
-      "cli",
-      "api-reference"
+      "demos/ui-builder"
     ]
   }
   


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: dependency version bumps across demo apps plus a documentation navigation reorder; no runtime logic changes in the repo itself.
> 
> **Overview**
> Bumps `@btst/stack` from `^2.5.0` to `^2.5.1` across all demo `package.json` files.
> 
> Reorders `docs/content/docs/meta.json` so the **Databases** and **Concepts** sections appear before **Demos** in the docs navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 504941db170190553df24434eb4622019ddc7eb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->