### PR TITLE
refactor:  cleanup singleton usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,25 +109,19 @@ Plugins expose write operations in a separate `api/mutations.ts` file — distin
 - Re-export from `api/index.ts` alongside getters
 - Common use case: AI tool `execute` callbacks, cron jobs, admin scripts
 
-**Adapter capture pattern for AI tool `execute` functions:**
+**Accessing the adapter in AI tool `execute` functions:**
 ```typescript
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _adapter: any
+export const myStack = stack({ ... })
 
 const myTool = tool({
   execute: async (params) => {
-    await createKanbanTask(_adapter, { title: params.title, columnId: "col-id" })
+    await createKanbanTask(myStack.adapter, { title: params.title, columnId: "col-id" })
     return { success: true }
   }
 })
-
-// With the global singleton pattern, use ??= so createStack() only runs once,
-// then ALWAYS assign _adapter after the ??= — never inside createStack().
-// During Next.js HMR the module re-evaluates (resetting `let` to undefined)
-// but createStack() doesn't re-run, so assignments inside it would be skipped.
-export const myStack = globalForStack.__btst_stack__ ??= createStack()
-_adapter = myStack.adapter
 ```
+
+`myStack` is a module-level `const`. The `execute` closure runs lazily — only when an HTTP request invokes the tool, never at module init time — so `myStack` is always defined by then.
 
 ### SSG Support (`prefetchForRoute`)
 
@@ -796,13 +790,7 @@ Plugin UI pages are distributed as a shadcn v4 registry so consumers can eject a
 
 17. **Putting write operations in `getters.ts`** - Write functions (create, update, delete) belong in `mutations.ts`, not `getters.ts`. This keeps the naming convention clear and signals to callers that no authorization hooks are invoked.
 
-18. **Tool `execute` adapter reference not set** - If a tool's `execute` function uses `_adapter` captured from `myStack.adapter`, assign it **after** the `??=` line, not inside `createStack()`. During Next.js HMR the module re-evaluates (resetting `let` variables to `undefined`), but `createStack()` does **not** re-run because the global already holds the stack — so any assignment inside `createStack()` is skipped. Place the assignment unconditionally after the export line so it runs on every module evaluation:
-
-```typescript
-export const myStack = globalForStack.__btst_stack__ ??= createStack()
-// Must be here — not inside createStack() — so HMR re-evaluation re-syncs the reference
-_adapter = myStack.adapter
-```
+18. **Singleton pattern only needed with the in-memory adapter in Next.js** — Next.js bundles API routes and page components into separate module contexts in the same process, so a bare `stack()` call at module level would create two independent in-memory adapter instances with different data. Use `globalThis` to share the instance only when using `@btst/adapter-memory` in Next.js. With any real database adapter (Drizzle, Prisma, MongoDB, etc.), just call `stack()` at module level — multiple adapter instances all read and write the same database.
 
 19. **Registry not rebuilt after plugin changes** — always run `pnpm --filter @btst/stack build-registry` and commit the updated JSON files. The CI auto-commits them if forgotten.
 

--- a/demos/ai-chat/lib/stack.ts
+++ b/demos/ai-chat/lib/stack.ts
@@ -4,6 +4,9 @@ import { aiChatBackendPlugin } from "@btst/stack/plugins/ai-chat/api";
 import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { openai } from "@ai-sdk/openai";
 
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 };

--- a/demos/blog/lib/stack.ts
+++ b/demos/blog/lib/stack.ts
@@ -4,8 +4,9 @@ import { blogBackendPlugin } from "@btst/stack/plugins/blog/api";
 import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { seedBlogData } from "./seed";
 
-// Persist stack and seed promise on `global` so Next.js module re-evaluations
-// (HMR, per-request server components) don't create a second instance or re-run the seed.
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 	__btst_seeded__?: Promise<void>;

--- a/demos/cms/lib/stack.ts
+++ b/demos/cms/lib/stack.ts
@@ -4,8 +4,9 @@ import { cmsBackendPlugin } from "@btst/stack/plugins/cms/api";
 import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { z } from "zod";
 import { seedCmsData } from "./seed";
-// Persist stack and seed promise on `global` so Next.js module re-evaluations
-// (HMR, per-request server components) don't create a second instance or re-run the seed.
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 	__btst_seeded__?: Promise<void>;

--- a/demos/form-builder/lib/stack.ts
+++ b/demos/form-builder/lib/stack.ts
@@ -4,8 +4,9 @@ import { formBuilderBackendPlugin } from "@btst/stack/plugins/form-builder/api";
 import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { seedFormBuilderData } from "./seed";
 
-// Persist stack and seed promise on `global` so Next.js module re-evaluations
-// (HMR, per-request server components) don't create a second instance or re-run the seed.
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 	__btst_seeded__?: Promise<void>;

--- a/demos/kanban/lib/stack.ts
+++ b/demos/kanban/lib/stack.ts
@@ -4,8 +4,9 @@ import { kanbanBackendPlugin } from "@btst/stack/plugins/kanban/api";
 import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { seedKanbanData } from "./seed";
 
-// Persist stack and seed promise on `global` so Next.js module re-evaluations
-// (HMR, per-request server components) don't create a second instance or re-run the seed.
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 	__btst_seeded__?: Promise<void>;

--- a/demos/ui-builder/lib/stack.ts
+++ b/demos/ui-builder/lib/stack.ts
@@ -5,8 +5,9 @@ import { openApiBackendPlugin } from "@btst/stack/plugins/open-api/api";
 import { UI_BUILDER_CONTENT_TYPE } from "@btst/stack/plugins/ui-builder";
 import { seedUIBuilderData } from "./seed";
 
-// Persist stack and seed promise on `global` so Next.js module re-evaluations
-// (HMR, per-request server components) don't create a second instance or re-run the seed.
+// In-memory adapter only: Next.js evaluates this module in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & {
 	__btst_stack__?: ReturnType<typeof createStack>;
 	__btst_seeded__?: Promise<void>;

--- a/examples/nextjs/lib/stack.ts
+++ b/examples/nextjs/lib/stack.ts
@@ -108,17 +108,10 @@ const blogHooks: BlogBackendHooks = {
     },
 };
 
-// Use a global singleton to share the same myStack (and in-memory adapter)
-// across Next.js module boundaries (API routes vs page/SSG bundles are bundled
-// separately, but all run in the same Node.js process).
+// In-memory adapter only: Next.js evaluates lib/stack.ts in multiple bundle contexts
+// (API routes + page bundle) that share the same process. Pin to globalThis so both
+// contexts reference the same in-memory store.
 const globalForStack = global as typeof global & { __btst_stack__?: ReturnType<typeof stack> };
-
-// WealthReview Demo — AI-native financial intake tool
-// Both references are set inside createStack() before any HTTP request fires.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let wealthReviewAdapter: any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let wealthReviewCmsApi: any
 
 const submitIntakeAssessment = tool({
     description:
@@ -161,17 +154,12 @@ const submitIntakeAssessment = tool({
             .describe("Your confidence in the recommendation (0–100)"),
     }),
     execute: async (params) => {
-        if (!wealthReviewAdapter) {
-            throw new Error("[WealthReview] Adapter not initialized")
-        }
-        const adapter = wealthReviewAdapter
-
         // 1. Persist client profile in CMS
         // Use api.cms.createContentItem (not the standalone mutation) so that
         // ensureSynced() runs first — required if no CMS HTTP request has been
         // made before this tool call (the content type won't exist otherwise).
         const slug = `client-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-        await wealthReviewCmsApi.createContentItem("client-profile", {
+        await myStack.api.cms.createContentItem("client-profile", {
             slug,
             data: {
                 ...params,
@@ -181,14 +169,14 @@ const submitIntakeAssessment = tool({
 
         // 2. Ensure the advisor review board exists (idempotent)
         const board = await findOrCreateKanbanBoard(
-            adapter,
+            myStack.adapter,
             "advisor-review-queue",
             "Advisor Review Queue",
             ["New Intakes", "Under Review", "Escalated"],
         )
 
         // 3. Route to the correct column
-        const columns = await getKanbanColumnsByBoardId(adapter, board.id)
+        const columns = await getKanbanColumnsByBoardId(myStack.adapter, board.id)
         const targetColumn = params.amlFlag
             ? (columns.find((c: { title: string }) => c.title === "Escalated") ?? columns[columns.length - 1])
             : (columns.find((c: { title: string }) => c.title === "New Intakes") ?? columns[0])
@@ -198,7 +186,7 @@ const submitIntakeAssessment = tool({
         }
 
         // 4. Create the Kanban review card
-        await createKanbanTask(adapter, {
+        await createKanbanTask(myStack.adapter, {
             title: `${params.clientName}${params.amlFlag ? " — ⚠️ ESCALATED" : " — Ready for Review"}`,
             columnId: targetColumn.id,
             priority: params.amlFlag ? "URGENT" : "MEDIUM",
@@ -393,11 +381,5 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 }
 
 export const myStack = globalForStack.__btst_stack__ ??= createStack()
-
-// Re-assign after the ??= so these are always valid, even after Next.js HMR
-// re-evaluates this module (which resets the `let` variables to undefined while
-// createStack() does NOT re-run because the global already holds the stack).
-wealthReviewAdapter = myStack.adapter
-wealthReviewCmsApi = myStack.api.cms
 
 export const { handler, dbSchema } = myStack


### PR DESCRIPTION


## Summary

<!-- What does this PR do and why? 1–3 bullet points. -->

- update the singleton memory adapter access pattern in demos and example projects

## Type of change

- [ ] Bug fix
- [ ] New plugin
- [ ] Feature / enhancement to an existing plugin
- [ ] Documentation
- [x] Chore / refactor / tooling

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Tests added or updated (unit and/or E2E)
- [ ] Docs updated (`docs/content/docs/`) if consumer-facing types or behavior changed
- [x] All three example apps updated if a plugin was added or changed
- [ ] New plugin: submission checklist in [CONTRIBUTING.md](../CONTRIBUTING.md#submission-checklist) completed

## Screenshots

<!-- Include before/after screenshots for UI changes, or delete this section. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and demo/example refactors; runtime behavior changes are limited to how AI tool `execute` callbacks reference `myStack.adapter`, which should be safe but could affect edge cases if module initialization fails before `myStack` is set.
> 
> **Overview**
> Clarifies and updates the recommended Next.js pattern for sharing an in-memory adapter: use a `globalThis`-pinned `myStack` singleton only for `@btst/adapter-memory`, and call `stack()` at module scope for real DB adapters.
> 
> Refactors the Next.js example AI tool `execute` logic to directly use `myStack.api.*` and `myStack.adapter` instead of capturing adapter/api references in `let` variables (removing the extra HMR re-assignment pattern), and updates demo `lib/stack.ts` files/comments to match the new guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df370c27960c1fb044e5cd528ecddd0a1ae76ec4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->