### PR TITLE
fix(stack): support request-aware page clients

### DIFF
--- a/docs/content/docs/breaking-changes.mdx
+++ b/docs/content/docs/breaking-changes.mdx
@@ -71,6 +71,13 @@ Use the equivalent pair for your framework:
 The [installation guide](/installation) has complete route files for all three
 frameworks.
 
+All three page factories also support request-aware client creation. Next.js
+awaits `getStackClient` with the current page props, React Router exposes
+`page.createLoader()` with its request and router context, and TanStack accepts
+an isomorphic `getLoaderStackClient` resolver with its loader context. Existing
+synchronous factories remain valid; see the installation guide's
+request-aware examples when SSR authorization needs headers or session state.
+
 ### 2. Move shared services to `StackProvider`
 
 Remove framework and API fields from every built-in plugin override. Configure

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -739,12 +739,107 @@ In order to use BTST, your application must meet the following requirements:
       The factory matches the URL to a plugin route via `stackClient.router.getRoute(path)`, prefetches data server-side with `route.loader()`, renders the route's `PageComponent` with instant hydration on the client, and generates SEO metadata from `route.meta()` (running the loader first, so meta can read prefetched data).
 
       **Factory options:**
-      - `createNextPage` accepts `notFound`, `wrapPage`, and `dehydrateOptions`.
-      - `createReactRouterPage` accepts `NotFound`, `ErrorBoundary`, `wrapPage`, and `dehydrateOptions`.
-      - `createTanStackPageOptions` accepts `getQueryClient` when the QueryClient is not available from router context.
+      - `createNextPage` accepts an async `getStackClient`, plus `notFound`, `wrapPage`, and `dehydrateOptions`.
+      - `createReactRouterPage` exposes `createLoader()` for async request-aware stack clients and accepts `NotFound`, `ErrorBoundary`, `wrapPage`, and `dehydrateOptions`.
+      - `createTanStackPageOptions` accepts `getLoaderStackClient` for async context-aware loaders and `getQueryClient` when the QueryClient is not available from router context.
 
       Use these options to customize the entry factory without reimplementing
       route matching, loader ordering, hydration, metadata, or 404 handling.
+    </Callout>
+
+    <Callout type="info">
+      **Request-aware stack clients**
+
+      Keep session and authorization policy in your application. The entry
+      factories pass each framework's native lifecycle context to an async
+      resolver while preserving a synchronous client for browser rendering.
+
+      <Tabs groupId="frameworks" items={["next-js", "react-router", "tanstack"]} persist>
+        <Tab value="next-js">
+          Next.js page and metadata functions run on the server, so the main
+          resolver can await request headers and session state directly:
+
+          ```tsx
+          import { headers } from "next/headers"
+          import { createNextPage } from "@btst/stack/next"
+          import { getOrCreateQueryClient } from "@/lib/query-client"
+          import { getStackClientForRequest } from "@/lib/stack-client"
+
+          const page = createNextPage({
+            getQueryClient: getOrCreateQueryClient,
+            getStackClient: async (queryClient, pageProps) => {
+              const requestHeaders = await headers()
+              return getStackClientForRequest(queryClient, {
+                headers: new Headers(requestHeaders),
+                pageProps,
+              })
+            },
+          })
+
+          export default page.Page
+          export const generateMetadata = page.generateMetadata
+          ```
+        </Tab>
+
+        <Tab value="react-router">
+          React Router framework loaders are server-only, but the route
+          component also renders in the browser. Keep the normal client
+          synchronous and create a request-aware loader separately:
+
+          ```tsx
+          import { createReactRouterPage } from "@btst/stack/react-router"
+          import { getOrCreateQueryClient } from "~/lib/query-client"
+          import { getStackClient } from "~/lib/stack-client"
+          import { getStackClientForRequest } from "~/lib/stack-client.server"
+
+          const page = createReactRouterPage({
+            getStackClient,
+            getQueryClient: getOrCreateQueryClient,
+          })
+
+          export const loader = page.createLoader(
+            async (queryClient, { request, context, params }) =>
+              getStackClientForRequest(queryClient, {
+                headers: request.headers,
+                context,
+                params,
+              }),
+          )
+          export const meta = page.meta
+          export default page.Component
+          ```
+        </Tab>
+
+        <Tab value="tanstack">
+          TanStack loaders run during SSR and browser navigation. Supply an
+          isomorphic resolver and put request-derived session data in router
+          context before the loader runs:
+
+          ```tsx
+          import type { QueryClient } from "@tanstack/react-query"
+          import { createFileRoute } from "@tanstack/react-router"
+          import { createTanStackPageOptions } from "@btst/stack/tanstack"
+          import type { AppSession } from "@/lib/auth"
+          import { getStackClient, getStackClientForLoad } from "@/lib/stack-client"
+
+          type AppRouterContext = {
+            queryClient: QueryClient
+            session: AppSession | null
+          }
+
+          export const Route = createFileRoute("/pages/$")(
+            createTanStackPageOptions<AppRouterContext>({
+              getStackClient,
+              getLoaderStackClient: (queryClient, { context, params }) =>
+                getStackClientForLoad(queryClient, {
+                  session: context.session,
+                  params,
+                }),
+            }),
+          )
+          ```
+        </Tab>
+      </Tabs>
     </Callout>
 
   </Step>

--- a/packages/stack/src/__tests__/entry-factories.test.tsx
+++ b/packages/stack/src/__tests__/entry-factories.test.tsx
@@ -23,6 +23,14 @@ function makeQueryClient() {
 	});
 }
 
+function reactRouterLoaderArgs(splat: string) {
+	return {
+		request: new Request(`http://test.local/${splat}`),
+		params: { "*": splat },
+		context: undefined,
+	};
+}
+
 const okHandler = async (request: Request) =>
 	new Response(`ok:${request.method}`);
 
@@ -96,6 +104,28 @@ describe("createNextPage", () => {
 		expect(html).toContain("blog page");
 	});
 
+	it("supports an async request-aware stack client when rendering", async () => {
+		const queryClient = makeQueryClient();
+		const pageProps = { params: params(["account"]) };
+		const page = createNextPage({
+			getStackClient: async (currentQueryClient, currentPageProps) => {
+				const { all } = await currentPageProps.params;
+				return makeStackClient({
+					[`/${all?.join("/")}`]: {
+						PageComponent: () => <div>request-aware page</div>,
+					},
+				})(currentQueryClient);
+			},
+			getQueryClient: () => queryClient,
+		});
+
+		const element = await page.Page(pageProps);
+		const html = renderToString(
+			<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>,
+		);
+		expect(html).toContain("request-aware page");
+	});
+
 	it("calls notFound when no route matches", async () => {
 		const notFound = vi.fn(() => {
 			throw new Error("NEXT_NOT_FOUND_TEST");
@@ -140,6 +170,26 @@ describe("createNextPage", () => {
 		});
 	});
 
+	it("generateMetadata awaits a request-aware stack client", async () => {
+		const page = createNextPage({
+			getStackClient: async (queryClient, { params: pageParams }) => {
+				const { all } = await pageParams;
+				return makeStackClient({
+					[`/${all?.join("/")}`]: {
+						meta: () => [{ name: "title", content: "Request Metadata" }],
+					},
+				})(queryClient);
+			},
+			getQueryClient: makeQueryClient,
+		});
+
+		const metadata = await page.generateMetadata({
+			params: params(["account"]),
+		});
+
+		expect(metadata).toMatchObject({ title: "Request Metadata" });
+	});
+
 	it("generateMetadata returns {} without running the loader when the route has no meta", async () => {
 		const loader = vi.fn();
 		const page = createNextPage({
@@ -170,6 +220,35 @@ describe("createNextPage", () => {
 });
 
 describe("createReactRouterPage", () => {
+	it("creates an async request-aware loader without changing the render client", async () => {
+		const queryClient = makeQueryClient();
+		const page = createReactRouterPage({
+			getStackClient: makeStackClient({}),
+			getQueryClient: () => queryClient,
+		});
+		const loader = page.createLoader<{ role: string }>(
+			async (currentQueryClient, { request, context }) => {
+				const role = context.role;
+				const requestRole = request.headers.get("x-role");
+				return makeStackClient({
+					"/account": {
+						meta: () => [{ name: "viewer", content: `${role}:${requestRole}` }],
+					},
+				})(currentQueryClient);
+			},
+		);
+
+		const data = await loader({
+			params: { "*": "account" },
+			request: new Request("http://test.local/account", {
+				headers: { "x-role": "member" },
+			}),
+			context: { role: "admin" },
+		});
+
+		expect(data.meta).toEqual([{ name: "viewer", content: "admin:member" }]);
+	});
+
 	it("loader prefetches and returns path, dehydratedState and meta", async () => {
 		const queryClient = makeQueryClient();
 		const page = createReactRouterPage({
@@ -187,7 +266,7 @@ describe("createReactRouterPage", () => {
 			getQueryClient: () => queryClient,
 		});
 
-		const data = await page.loader({ params: { "*": "blog" } });
+		const data = await page.loader(reactRouterLoaderArgs("blog"));
 		expect(data.path).toBe("/blog");
 		expect(data.meta).toEqual([{ name: "title", content: "Blog" }]);
 		expect(data.dehydratedState.queries).toHaveLength(1);
@@ -215,7 +294,7 @@ describe("createReactRouterPage", () => {
 			getQueryClient: () => queryClient,
 		});
 
-		const data = await page.loader({ params: { "*": "broken" } });
+		const data = await page.loader(reactRouterLoaderArgs("broken"));
 		const errored = data.dehydratedState.queries.find(
 			(q) => q.state.status === "error",
 		);
@@ -244,12 +323,33 @@ describe("createReactRouterPage", () => {
 		});
 
 		expect(page.ErrorBoundary).toBe(CustomErrorBoundary);
-		const data = await page.loader({ params: { "*": "broken" } });
+		const data = await page.loader(reactRouterLoaderArgs("broken"));
 		expect(data.dehydratedState.queries).toHaveLength(0);
 	});
 });
 
 describe("createTanStackPageOptions", () => {
+	it("awaits a context-aware stack client for isomorphic loaders", async () => {
+		const queryClient = makeQueryClient();
+		const options = createTanStackPageOptions<{ role: string }>({
+			getStackClient: makeStackClient({}),
+			getQueryClient: () => queryClient,
+			getLoaderStackClient: async (currentQueryClient, { context }) =>
+				makeStackClient({
+					"/account": {
+						meta: () => [{ title: `Account for ${context.role}` }],
+					},
+				})(currentQueryClient),
+		});
+
+		const data = await options.loader({
+			params: { _splat: "account" },
+			context: { role: "admin" },
+		});
+
+		expect(data).toEqual({ meta: [{ title: "Account for admin" }] });
+	});
+
 	it("loader throws notFound() when no route matches", async () => {
 		const options = createTanStackPageOptions({
 			getStackClient: makeStackClient({}),
@@ -257,7 +357,7 @@ describe("createTanStackPageOptions", () => {
 		});
 
 		await expect(
-			options.loader({ params: { _splat: "missing" } }),
+			options.loader({ params: { _splat: "missing" }, context: undefined }),
 		).rejects.toMatchObject({ isNotFound: true });
 	});
 

--- a/packages/stack/src/next/index.tsx
+++ b/packages/stack/src/next/index.tsx
@@ -1,11 +1,13 @@
 export { toNextRouteHandlers } from "./handlers";
 export {
 	type CreateNextPageOptions,
+	type GetNextStackClient,
 	type NextPageProps,
 	createNextPage,
 } from "./page";
 export { nextRouter } from "./router";
 export type {
 	GetStackClient,
+	ResolveStackClient,
 	StackRequestHandler,
 } from "../shared/entry-factories";

--- a/packages/stack/src/next/page.tsx
+++ b/packages/stack/src/next/page.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import { metaElementsToObject } from "../client/meta-utils";
 import { normalizePath } from "../client/path-utils";
 import {
-	type GetStackClient,
+	type ResolveStackClient,
 	stackDehydrateOptions,
 } from "../shared/entry-factories";
 
@@ -14,9 +14,15 @@ export interface NextPageProps {
 	params: Promise<{ all?: string[] }>;
 }
 
+/** Resolves the stack client for a Next.js page or metadata request. */
+export type GetNextStackClient = ResolveStackClient<NextPageProps>;
+
 export interface CreateNextPageOptions {
-	/** Returns the stack client for a given QueryClient (`lib/stack-client`). */
-	getStackClient: GetStackClient;
+	/**
+	 * Returns the stack client for the current request. May be async and receives
+	 * the page props so request-aware clients can resolve request-local state.
+	 */
+	getStackClient: GetNextStackClient;
 	/** Returns the QueryClient for the current context (`lib/query-client`). */
 	getQueryClient: () => QueryClient;
 	/**
@@ -63,11 +69,13 @@ export function createNextPage(options: CreateNextPageOptions) {
 		dehydrateOptions = stackDehydrateOptions,
 	} = options;
 
-	async function Page({ params }: NextPageProps) {
+	async function Page(pageProps: NextPageProps) {
+		const { params } = pageProps;
 		const pathParams = await params;
 		const path = normalizePath(pathParams?.all);
 		const queryClient = getQueryClient();
-		const route = getStackClient(queryClient).router.getRoute(path);
+		const stackClient = await getStackClient(queryClient, pageProps);
+		const route = stackClient.router.getRoute(path);
 
 		if (route?.loader) {
 			await route.loader();
@@ -82,13 +90,13 @@ export function createNextPage(options: CreateNextPageOptions) {
 		);
 	}
 
-	async function generateMetadata({
-		params,
-	}: NextPageProps): Promise<Metadata> {
+	async function generateMetadata(pageProps: NextPageProps): Promise<Metadata> {
+		const { params } = pageProps;
 		const pathParams = await params;
 		const path = normalizePath(pathParams?.all);
 		const queryClient = getQueryClient();
-		const route = getStackClient(queryClient).router.getRoute(path);
+		const stackClient = await getStackClient(queryClient, pageProps);
+		const route = stackClient.router.getRoute(path);
 
 		if (!route) {
 			return notFound();

--- a/packages/stack/src/react-router/index.tsx
+++ b/packages/stack/src/react-router/index.tsx
@@ -7,5 +7,6 @@ export {
 export { reactRouter } from "./router";
 export type {
 	GetStackClient,
+	ResolveStackClient,
 	StackRequestHandler,
 } from "../shared/entry-factories";

--- a/packages/stack/src/react-router/page.tsx
+++ b/packages/stack/src/react-router/page.tsx
@@ -10,6 +10,7 @@ import { useLoaderData, useRouteError } from "react-router";
 import { normalizePath } from "../client/path-utils";
 import {
 	type GetStackClient,
+	type ResolveStackClient,
 	stackDehydrateOptions,
 } from "../shared/entry-factories";
 
@@ -19,8 +20,13 @@ import {
  * are not available inside the library, so the factory types the subset it
  * uses; the results remain assignable to the generated route exports.
  */
-export interface ReactRouterPageLoaderArgs {
+export interface ReactRouterPageLoaderArgs<TContext = unknown> {
+	/** The request that triggered the route loader. */
+	request: Request;
+	/** Parameters for the React Router catch-all route. */
 	params: { "*"?: string } & Record<string, string | undefined>;
+	/** Request-local values supplied by React Router middleware. */
+	context: TContext;
 }
 
 export interface CreateReactRouterPageOptions {
@@ -75,21 +81,36 @@ export function createReactRouterPage(options: CreateReactRouterPageOptions) {
 		dehydrateOptions = stackDehydrateOptions,
 	} = options;
 
-	async function loader({ params }: ReactRouterPageLoaderArgs) {
-		const queryClient = getQueryClient();
-		const path = normalizePath(params["*"]);
-		const route = getStackClient(queryClient).router.getRoute(path);
+	/** Creates a loader with an optional async, request-aware stack client. */
+	function createLoader<TContext = unknown>(
+		getLoaderStackClient?: ResolveStackClient<
+			ReactRouterPageLoaderArgs<TContext>
+		>,
+	) {
+		return async function loader(
+			loaderArgs: ReactRouterPageLoaderArgs<TContext>,
+		) {
+			const { params } = loaderArgs;
+			const queryClient = getQueryClient();
+			const path = normalizePath(params["*"]);
+			const stackClient = getLoaderStackClient
+				? await getLoaderStackClient(queryClient, loaderArgs)
+				: getStackClient(queryClient);
+			const route = stackClient.router.getRoute(path);
 
-		if (route?.loader) {
-			await route.loader();
-		}
+			if (route?.loader) {
+				await route.loader();
+			}
 
-		return {
-			path,
-			dehydratedState: dehydrate(queryClient, dehydrateOptions),
-			meta: await route?.meta?.(),
+			return {
+				path,
+				dehydratedState: dehydrate(queryClient, dehydrateOptions),
+				meta: await route?.meta?.(),
+			};
 		};
 	}
+
+	const loader = createLoader();
 
 	type LoaderData = Awaited<ReturnType<typeof loader>>;
 
@@ -132,6 +153,7 @@ export function createReactRouterPage(options: CreateReactRouterPageOptions) {
 
 	return {
 		loader,
+		createLoader,
 		meta,
 		Component,
 		ErrorBoundary: CustomErrorBoundary ?? DefaultErrorBoundary,

--- a/packages/stack/src/shared/entry-factories.ts
+++ b/packages/stack/src/shared/entry-factories.ts
@@ -36,6 +36,15 @@ export interface StackClientLike {
 export type GetStackClient = (queryClient: QueryClient) => StackClientLike;
 
 /**
+ * Consumer-provided resolver for lifecycle phases that can await request-aware
+ * stack client creation.
+ */
+export type ResolveStackClient<TContext> = (
+	queryClient: QueryClient,
+	context: TContext,
+) => StackClientLike | PromiseLike<StackClientLike>;
+
+/**
  * A framework-agnostic BTST API handler, as returned by
  * `createBackendHandler(...).handler`.
  */

--- a/packages/stack/src/tanstack/index.tsx
+++ b/packages/stack/src/tanstack/index.tsx
@@ -1,10 +1,12 @@
 export { toTanStackHandlers } from "./handlers";
 export {
 	type CreateTanStackPageOptions,
+	type TanStackPageLoaderArgs,
 	createTanStackPageOptions,
 } from "./page";
 export { tanstackRouter } from "./router";
 export type {
 	GetStackClient,
+	ResolveStackClient,
 	StackRequestHandler,
 } from "../shared/entry-factories";

--- a/packages/stack/src/tanstack/page.tsx
+++ b/packages/stack/src/tanstack/page.tsx
@@ -2,22 +2,33 @@ import type { QueryClient } from "@tanstack/react-query";
 import { notFound, useParams, useRouteContext } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { normalizePath } from "../client/path-utils";
-import type { GetStackClient } from "../shared/entry-factories";
+import type {
+	GetStackClient,
+	ResolveStackClient,
+} from "../shared/entry-factories";
 
-export interface CreateTanStackPageOptions {
+export interface TanStackPageLoaderArgs<TContext = unknown> {
+	/** Parameters for the TanStack catch-all route. */
+	params: { _splat?: string };
+	/** The current TanStack router context. */
+	context: TContext;
+}
+
+export interface CreateTanStackPageOptions<TContext = unknown> {
 	/** Returns the stack client for a given QueryClient (`lib/stack-client`). */
 	getStackClient: GetStackClient;
+	/**
+	 * Resolves the stack client for the isomorphic route loader. Use an
+	 * isomorphic adapter when request-aware setup differs on the server and
+	 * client. Defaults to `getStackClient`.
+	 */
+	getLoaderStackClient?: ResolveStackClient<TanStackPageLoaderArgs<TContext>>;
 	/**
 	 * Returns the QueryClient for the current context. Defaults to the
 	 * `queryClient` from the router context (set up by
 	 * `setupRouterSsrQueryIntegration`).
 	 */
 	getQueryClient?: () => QueryClient;
-}
-
-interface TanStackPageLoaderArgs {
-	params: { _splat?: string };
-	context?: unknown;
 }
 
 /**
@@ -39,8 +50,10 @@ interface TanStackPageLoaderArgs {
  * );
  * ```
  */
-export function createTanStackPageOptions(options: CreateTanStackPageOptions) {
-	const { getStackClient, getQueryClient } = options;
+export function createTanStackPageOptions<TContext = unknown>(
+	options: CreateTanStackPageOptions<TContext>,
+) {
+	const { getStackClient, getLoaderStackClient, getQueryClient } = options;
 
 	function resolveQueryClient(context: unknown): QueryClient {
 		const fromContext = (context as { queryClient?: QueryClient } | null)
@@ -78,10 +91,14 @@ export function createTanStackPageOptions(options: CreateTanStackPageOptions) {
 	return {
 		ssr: true,
 		component: PageComponent,
-		loader: async ({ params, context }: TanStackPageLoaderArgs) => {
+		loader: async (loaderArgs: TanStackPageLoaderArgs<TContext>) => {
+			const { params, context } = loaderArgs;
 			const queryClient = resolveQueryClient(context);
 			const routePath = normalizePath(params._splat);
-			const route = getStackClient(queryClient).router.getRoute(routePath);
+			const stackClient = getLoaderStackClient
+				? await getLoaderStackClient(queryClient, loaderArgs)
+				: getStackClient(queryClient);
+			const route = stackClient.router.getRoute(routePath);
 			if (!route) throw notFound();
 			if (route.loader) await route.loader();
 			return { meta: await route.meta?.() };

--- a/scripts/codegen/files/nextjs/app/pages/[[...all]]/page.tsx
+++ b/scripts/codegen/files/nextjs/app/pages/[[...all]]/page.tsx
@@ -1,0 +1,19 @@
+import { createNextPage } from "@btst/stack/next";
+import { headers } from "next/headers";
+import { getOrCreateQueryClient } from "@/lib/query-client";
+import { getStackClient } from "@/lib/stack-client";
+
+export const dynamic = "force-dynamic";
+
+const page = createNextPage({
+	getQueryClient: getOrCreateQueryClient,
+	getStackClient: async (queryClient, pageProps) => {
+		const requestHeaders = await headers();
+		await pageProps.params;
+		void requestHeaders.get("host");
+		return getStackClient(queryClient);
+	},
+});
+
+export default page.Page;
+export const generateMetadata = page.generateMetadata;

--- a/scripts/codegen/files/react-router/app/lib/stack-client.server.ts
+++ b/scripts/codegen/files/react-router/app/lib/stack-client.server.ts
@@ -1,0 +1,10 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getStackClient } from "~/lib/stack-client";
+
+export async function getStackClientForRequest(
+	queryClient: QueryClient,
+	request: Request,
+) {
+	void request.headers.get("host");
+	return getStackClient(queryClient);
+}

--- a/scripts/codegen/files/react-router/app/routes/pages/$.tsx
+++ b/scripts/codegen/files/react-router/app/routes/pages/$.tsx
@@ -1,0 +1,16 @@
+import { createReactRouterPage } from "@btst/stack/react-router";
+import { getOrCreateQueryClient } from "~/lib/query-client";
+import { getStackClient } from "~/lib/stack-client";
+import { getStackClientForRequest } from "~/lib/stack-client.server";
+
+const page = createReactRouterPage({
+	getStackClient,
+	getQueryClient: getOrCreateQueryClient,
+});
+
+export const loader = page.createLoader((queryClient, { request }) =>
+	getStackClientForRequest(queryClient, request),
+);
+export const meta = page.meta;
+export const ErrorBoundary = page.ErrorBoundary;
+export default page.Component;

--- a/scripts/codegen/files/tanstack/src/routes/pages/$.tsx
+++ b/scripts/codegen/files/tanstack/src/routes/pages/$.tsx
@@ -1,7 +1,14 @@
 import { createTanStackPageOptions } from "@btst/stack/tanstack";
 import { createFileRoute } from "@tanstack/react-router";
 import { getStackClient } from "@/lib/stack-client";
+import type { MyRouterContext } from "@/router";
 
 export const Route = createFileRoute("/pages/$")(
-	createTanStackPageOptions({ getStackClient }),
+	createTanStackPageOptions<MyRouterContext>({
+		getStackClient,
+		getLoaderStackClient: async (queryClient, { context }) => {
+			void context.queryClient.getQueryCache();
+			return getStackClient(queryClient);
+		},
+	}),
 );

--- a/scripts/codegen/update-files-nextjs.sh
+++ b/scripts/codegen/update-files-nextjs.sh
@@ -36,6 +36,7 @@ FILES=(
   "app/directory/page.tsx"
   "app/layout.tsx"
   "app/pages/layout.tsx"
+  "app/pages/[[...all]]/page.tsx"
   "components/mode-toggle.tsx"
   "components/navbar.tsx"
   "lib/adapters-build-check.ts"

--- a/scripts/codegen/update-files-react-router.sh
+++ b/scripts/codegen/update-files-react-router.sh
@@ -40,6 +40,7 @@ FILES=(
   "app/lib/plugins/todo/types.ts"
   "app/lib/stack-auth.ts"
   "app/lib/stack-client.tsx"
+  "app/lib/stack-client.server.ts"
   "app/lib/stack-public-chat.ts"
   "app/lib/stack.ts"
   "app/root.tsx"
@@ -51,6 +52,7 @@ FILES=(
   "app/routes/directory/index.tsx"
   "app/routes/directory/resource.\$id.tsx"
   "app/routes/pages/_layout.tsx"
+  "app/routes/pages/\$.tsx"
 )
 
 COUNT=0


### PR DESCRIPTION
## Summary

- allow Next.js page and metadata factories to await request-aware stack clients using page props
- add a React Router loader factory that receives the request and router context while keeping render-time client access synchronous
- add a TanStack loader client resolver that can await router-context-aware clients while preserving synchronous component usage
- document the three framework patterns and cover them in unit and generated-app E2E fixtures

## Validation

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (598 tests)
- docs production build
- Next.js generated-app E2E (150 passed, 34 skipped)
- React Router generated-app E2E (147 passed, 34 skipped)
- TanStack Start generated-app E2E (147 passed, 34 skipped)

Closes #162