### PR TITLE
feat(stack): add symmetric stack constructors

### DIFF
--- a/packages/stack/consumer-tests/constructor-exports/index.cts
+++ b/packages/stack/consumer-tests/constructor-exports/index.cts
@@ -1,0 +1,33 @@
+import api = require("@btst/stack/api");
+import client = require("@btst/stack/client");
+
+type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <
+	T,
+>() => T extends TRight ? 1 : 2
+	? true
+	: false;
+type Expect<T extends true> = T;
+
+type _BackendFactoriesMatch = Expect<
+	Equal<typeof api.createBackendStack, typeof api.stack>
+>;
+type _ClientFactoriesMatch = Expect<
+	Equal<typeof client.createClientStack, typeof client.createStackClient>
+>;
+type _BackendConfigAliasMatches = Expect<
+	Equal<api.BackendStackConfig, api.BackendLibConfig>
+>;
+type _BackendResultAliasMatches = Expect<
+	Equal<api.BackendStack, api.BackendLib>
+>;
+type _ClientConfigAliasMatches = Expect<
+	Equal<client.ClientStackConfig, client.ClientLibConfig>
+>;
+type _ClientResultAliasMatches = Expect<
+	Equal<client.ClientStack, client.ClientLib>
+>;
+
+void api.createBackendStack;
+void api.stack;
+void client.createClientStack;
+void client.createStackClient;

--- a/packages/stack/consumer-tests/constructor-exports/index.ts
+++ b/packages/stack/consumer-tests/constructor-exports/index.ts
@@ -1,3 +1,5 @@
+import type { DatabaseDefinition, DBAdapter } from "@btst/db";
+import { z } from "zod";
 import {
 	createBackendStack,
 	stack,
@@ -7,6 +9,12 @@ import {
 	type BackendStackConfig,
 } from "@btst/stack/api";
 import {
+	defineAuthorization,
+	definePermissions,
+	permission,
+} from "@btst/stack/authorization";
+import { createServerAuth } from "@btst/stack/authorization/server";
+import {
 	createClientStack,
 	createStackClient,
 	type ClientLib,
@@ -14,6 +22,13 @@ import {
 	type ClientStack,
 	type ClientStackConfig,
 } from "@btst/stack/client";
+import {
+	createDbPlugin,
+	createEndpoint,
+	defineBackendPlugin,
+	defineOperation,
+} from "@btst/stack/plugins/api";
+import { createRoute, defineClientPlugin } from "@btst/stack/plugins/client";
 
 type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <
 	T,
@@ -22,22 +37,136 @@ type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <
 	: false;
 type Expect<T extends true> = T;
 
+const permissions = definePermissions("consumerProbe", {
+	read: permission(z.object({ id: z.string() })),
+});
+const authorization = defineAuthorization({
+	identity: z.object({ id: z.string() }),
+	permissions: [permissions] as const,
+	rules: ({ consumerProbe }) => [consumerProbe.read.allow()],
+});
+const auth = createServerAuth({
+	authorization,
+	getIdentity: () => ({ id: "user-1" }),
+});
+const read = defineOperation({
+	input: z.object({ id: z.string() }),
+	permission: permissions.read,
+	facts: ({ input }) => ({ id: input.id }),
+	execute: ({ input }) => ({ id: input.id }),
+});
+const backendPlugin = defineBackendPlugin({
+	name: "consumerProbe",
+	dbPlugin: createDbPlugin("consumerProbe", {}),
+	operations: () => ({ read }),
+	routes: (_adapter, _context, operations) => ({
+		read: createEndpoint(
+			"/consumer-probe/:id",
+			{ method: "GET", requireRequest: true },
+			operations.read.route((context) => ({ id: context.params.id })),
+		),
+	}),
+});
+const backendConfig = {
+	basePath: "/api",
+	plugins: { consumerProbe: backendPlugin },
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
+	auth,
+} satisfies BackendStackConfig<
+	{ consumerProbe: typeof backendPlugin },
+	typeof auth
+>;
+const canonicalBackend = createBackendStack(backendConfig);
+const temporaryBackend = stack(backendConfig);
+
 type _BackendFactoriesMatch = Expect<
 	Equal<typeof createBackendStack, typeof stack>
 >;
+type _BackendInferenceMatches = Expect<
+	Equal<typeof canonicalBackend, typeof temporaryBackend>
+>;
+type _BackendRouteInference = Expect<
+	Equal<keyof typeof canonicalBackend.router.endpoints, "consumerProbe_read">
+>;
+type _BackendConfigAliasMatches = Expect<
+	Equal<
+		BackendStackConfig<{ consumerProbe: typeof backendPlugin }, typeof auth>,
+		BackendLibConfig<{ consumerProbe: typeof backendPlugin }, typeof auth>
+	>
+>;
+type _BackendResultAliasMatches = Expect<
+	Equal<
+		BackendStack<
+			ReturnType<typeof backendPlugin.routes>,
+			Record<string, never>,
+			typeof canonicalBackend.internal
+		>,
+		BackendLib<
+			ReturnType<typeof backendPlugin.routes>,
+			Record<string, never>,
+			typeof canonicalBackend.internal
+		>
+	>
+>;
+canonicalBackend.router.endpoints.consumerProbe_read;
+canonicalBackend.internal.consumerProbe.read({ id: "record-1" });
+canonicalBackend
+	.forRequest(new Request("https://example.com/api"))
+	.api.consumerProbe.read({ id: "record-1" });
+
+const unrelatedPermissions = definePermissions("unrelated", {
+	read: permission(),
+});
+const incompatibleAuth = createServerAuth({
+	authorization: defineAuthorization({
+		identity: z.object({ id: z.string() }),
+		permissions: [unrelatedPermissions] as const,
+		rules: ({ unrelated }) => [unrelated.read.allow()],
+	}),
+	getIdentity: () => ({ id: "user-1" }),
+});
+createBackendStack({
+	...backendConfig,
+	// @ts-expect-error public canonical constructor rejects incompatible catalogs
+	auth: incompatibleAuth,
+});
+stack({
+	...backendConfig,
+	// @ts-expect-error public temporary constructor preserves catalog inference
+	auth: incompatibleAuth,
+});
+
+const clientPlugin = defineClientPlugin({
+	name: "consumerProbe",
+	routes: () => ({
+		read: createRoute("/consumer-probe/:id", ({ params }) => ({
+			PageComponent: () => null,
+			loader: async () => ({ recordId: params.id }),
+		})),
+	}),
+});
+const clientConfig = {
+	plugins: { consumerProbe: clientPlugin },
+} satisfies ClientStackConfig<{ consumerProbe: typeof clientPlugin }>;
+const canonicalClient = createClientStack(clientConfig);
+const temporaryClient = createStackClient(clientConfig);
+
 type _ClientFactoriesMatch = Expect<
 	Equal<typeof createClientStack, typeof createStackClient>
 >;
-type _BackendConfigAliasMatches = Expect<
-	Equal<BackendStackConfig, BackendLibConfig>
+type _ClientInferenceMatches = Expect<
+	Equal<typeof canonicalClient, typeof temporaryClient>
 >;
-type _BackendResultAliasMatches = Expect<Equal<BackendStack, BackendLib>>;
 type _ClientConfigAliasMatches = Expect<
-	Equal<ClientStackConfig, ClientLibConfig>
+	Equal<
+		ClientStackConfig<{ consumerProbe: typeof clientPlugin }>,
+		ClientLibConfig<{ consumerProbe: typeof clientPlugin }>
+	>
 >;
-type _ClientResultAliasMatches = Expect<Equal<ClientStack, ClientLib>>;
-
-void createBackendStack;
-void stack;
-void createClientStack;
-void createStackClient;
+type _ClientResultAliasMatches = Expect<
+	Equal<
+		ClientStack<ReturnType<typeof clientPlugin.routes>>,
+		ClientLib<ReturnType<typeof clientPlugin.routes>>
+	>
+>;
+canonicalClient.router.getRoute("/consumer-probe/record-1")?.loader?.();

--- a/packages/stack/consumer-tests/constructor-exports/index.ts
+++ b/packages/stack/consumer-tests/constructor-exports/index.ts
@@ -1,0 +1,43 @@
+import {
+	createBackendStack,
+	stack,
+	type BackendLib,
+	type BackendLibConfig,
+	type BackendStack,
+	type BackendStackConfig,
+} from "@btst/stack/api";
+import {
+	createClientStack,
+	createStackClient,
+	type ClientLib,
+	type ClientLibConfig,
+	type ClientStack,
+	type ClientStackConfig,
+} from "@btst/stack/client";
+
+type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <
+	T,
+>() => T extends TRight ? 1 : 2
+	? true
+	: false;
+type Expect<T extends true> = T;
+
+type _BackendFactoriesMatch = Expect<
+	Equal<typeof createBackendStack, typeof stack>
+>;
+type _ClientFactoriesMatch = Expect<
+	Equal<typeof createClientStack, typeof createStackClient>
+>;
+type _BackendConfigAliasMatches = Expect<
+	Equal<BackendStackConfig, BackendLibConfig>
+>;
+type _BackendResultAliasMatches = Expect<Equal<BackendStack, BackendLib>>;
+type _ClientConfigAliasMatches = Expect<
+	Equal<ClientStackConfig, ClientLibConfig>
+>;
+type _ClientResultAliasMatches = Expect<Equal<ClientStack, ClientLib>>;
+
+void createBackendStack;
+void stack;
+void createClientStack;
+void createStackClient;

--- a/packages/stack/consumer-tests/constructor-exports/tsconfig.cjs.json
+++ b/packages/stack/consumer-tests/constructor-exports/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true
+  },
+  "include": ["./index.cts"]
+}

--- a/packages/stack/consumer-tests/constructor-exports/tsconfig.json
+++ b/packages/stack/consumer-tests/constructor-exports/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": true
+  },
+  "include": ["./index.ts"]
+}

--- a/packages/stack/knip.json
+++ b/packages/stack/knip.json
@@ -67,6 +67,10 @@
   ],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.{ts,tsx,cjs}"],
   "ignore": ["src/**/*.test.{ts,tsx}", "dist/**"],
+  "ignoreIssues": {
+    "src/api/index.ts": ["duplicates"],
+    "src/client/index.ts": ["duplicates"]
+  },
   "ignoreDependencies": [
     "@radix-ui/react-dialog",
     "@radix-ui/react-label",

--- a/packages/stack/src/__tests__/package-metadata.test.ts
+++ b/packages/stack/src/__tests__/package-metadata.test.ts
@@ -1,6 +1,11 @@
+import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
 
 describe("published dependency alignment", () => {
 	it("uses the Better DB release that shares the Better Auth 1.6.16 cohort", async () => {
@@ -17,5 +22,66 @@ describe("published dependency alignment", () => {
 		expect(manifest.devDependencies?.["@btst/yar"]).toBe("1.3.2");
 		expect(manifest.peerDependencies?.["@btst/yar"]).toBe(">=1.3.2");
 		expect(manifest.peerDependencies?.["better-call"]).toBe("1.3.6");
+	});
+});
+
+describe("published symmetric stack constructors", () => {
+	it("exposes canonical and temporary names through ESM, CJS, declarations and typesVersions", async () => {
+		const manifest = JSON.parse(
+			await readFile(resolve("package.json"), "utf8"),
+		) as {
+			exports?: Record<string, unknown>;
+			typesVersions?: Record<string, Record<string, string[]>>;
+		};
+		expect(manifest.exports).toHaveProperty("./api");
+		expect(manifest.exports).toHaveProperty("./client");
+		expect(manifest.typesVersions?.["*"]?.api).toEqual([
+			"./dist/api/index.d.ts",
+		]);
+		expect(manifest.typesVersions?.["*"]?.client).toEqual([
+			"./dist/client/index.d.ts",
+		]);
+
+		const apiDeclaration = await readFile(
+			resolve("dist/api/index.d.ts"),
+			"utf8",
+		);
+		const clientDeclaration = await readFile(
+			resolve("dist/client/index.d.ts"),
+			"utf8",
+		);
+		expect(apiDeclaration).toContain("function createBackendStack");
+		expect(apiDeclaration).toContain("const stack: typeof createBackendStack");
+		expect(apiDeclaration).toContain("BackendStackConfig");
+		expect(apiDeclaration).toContain("BackendStack<");
+		expect(clientDeclaration).toContain("function createClientStack");
+		expect(clientDeclaration).toContain(
+			"const createStackClient: typeof createClientStack",
+		);
+		expect(clientDeclaration).toContain("ClientStackConfig");
+		expect(clientDeclaration).toContain("ClientStack<");
+
+		const apiSpecifier = "@btst/stack/api";
+		const clientSpecifier = "@btst/stack/client";
+		const esmApi = await import(apiSpecifier);
+		const esmClient = await import(clientSpecifier);
+		const require = createRequire(import.meta.url);
+		const cjsApi = require(apiSpecifier);
+		const cjsClient = require(clientSpecifier);
+
+		expect(esmApi.stack).toBe(esmApi.createBackendStack);
+		expect(esmClient.createStackClient).toBe(esmClient.createClientStack);
+		expect(cjsApi.stack).toBe(cjsApi.createBackendStack);
+		expect(cjsClient.createStackClient).toBe(cjsClient.createClientStack);
+
+		await execFileAsync(
+			process.execPath,
+			[
+				require.resolve("typescript/lib/tsc.js"),
+				"--project",
+				"consumer-tests/constructor-exports/tsconfig.json",
+			],
+			{ cwd: resolve(".") },
+		);
 	});
 });

--- a/packages/stack/src/__tests__/package-metadata.test.ts
+++ b/packages/stack/src/__tests__/package-metadata.test.ts
@@ -50,16 +50,42 @@ describe("published symmetric stack constructors", () => {
 			resolve("dist/client/index.d.ts"),
 			"utf8",
 		);
-		expect(apiDeclaration).toContain("function createBackendStack");
-		expect(apiDeclaration).toContain("const stack: typeof createBackendStack");
-		expect(apiDeclaration).toContain("BackendStackConfig");
-		expect(apiDeclaration).toContain("BackendStack<");
-		expect(clientDeclaration).toContain("function createClientStack");
-		expect(clientDeclaration).toContain(
-			"const createStackClient: typeof createClientStack",
+		const apiCjsDeclaration = await readFile(
+			resolve("dist/api/index.d.cts"),
+			"utf8",
 		);
-		expect(clientDeclaration).toContain("ClientStackConfig");
-		expect(clientDeclaration).toContain("ClientStack<");
+		const clientCjsDeclaration = await readFile(
+			resolve("dist/client/index.d.cts"),
+			"utf8",
+		);
+		for (const declaration of [apiDeclaration, apiCjsDeclaration]) {
+			expect(declaration).toContain("function createBackendStack");
+			expect(declaration).toContain("const stack: typeof createBackendStack");
+			expect(declaration).toContain("BackendStackConfig");
+			expect(declaration).toContain("BackendStack<");
+			expect(declaration).toMatch(
+				/@deprecated Use `createBackendStack`[\s\S]*const stack: typeof createBackendStack/,
+			);
+			const canonicalSignature = declaration.match(
+				/function createBackendStack[\s\S]*?;/,
+			)?.[0];
+			expect(canonicalSignature).not.toContain("BackendLib");
+		}
+		for (const declaration of [clientDeclaration, clientCjsDeclaration]) {
+			expect(declaration).toContain("function createClientStack");
+			expect(declaration).toContain(
+				"const createStackClient: typeof createClientStack",
+			);
+			expect(declaration).toContain("ClientStackConfig");
+			expect(declaration).toContain("ClientStack<");
+			expect(declaration).toMatch(
+				/@deprecated Use `createClientStack`[\s\S]*const createStackClient: typeof createClientStack/,
+			);
+			const canonicalSignature = declaration.match(
+				/function createClientStack[\s\S]*?;/,
+			)?.[0];
+			expect(canonicalSignature).not.toContain("ClientLib");
+		}
 
 		const apiSpecifier = "@btst/stack/api";
 		const clientSpecifier = "@btst/stack/client";
@@ -80,6 +106,15 @@ describe("published symmetric stack constructors", () => {
 				require.resolve("typescript/lib/tsc.js"),
 				"--project",
 				"consumer-tests/constructor-exports/tsconfig.json",
+			],
+			{ cwd: resolve(".") },
+		);
+		await execFileAsync(
+			process.execPath,
+			[
+				require.resolve("typescript/lib/tsc.js"),
+				"--project",
+				"consumer-tests/constructor-exports/tsconfig.cjs.json",
 			],
 			{ cwd: resolve(".") },
 		);

--- a/packages/stack/src/__tests__/package-metadata.test.ts
+++ b/packages/stack/src/__tests__/package-metadata.test.ts
@@ -118,5 +118,5 @@ describe("published symmetric stack constructors", () => {
 			],
 			{ cwd: resolve(".") },
 		);
-	});
+	}, 30_000);
 });

--- a/packages/stack/src/__tests__/stack-constructors.test.ts
+++ b/packages/stack/src/__tests__/stack-constructors.test.ts
@@ -1,0 +1,103 @@
+import { createMemoryAdapter } from "@btst/adapter-memory";
+import { createDbPlugin, type DatabaseDefinition } from "@btst/db";
+import { createRoute } from "@btst/yar";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createBackendStack, stack } from "../api";
+import { definePermissions, permission } from "../authorization";
+import { createClientStack, createStackClient } from "../client";
+import {
+	createEndpoint,
+	defineBackendPlugin,
+	defineOperation,
+} from "../plugins/api";
+import { defineClientPlugin } from "../plugins/client";
+
+const adapter = (db: DatabaseDefinition) => createMemoryAdapter(db)({});
+const probePermissions = definePermissions("probe", {
+	echo: permission(z.object({ value: z.string() })),
+});
+const probeOperation = defineOperation({
+	access: "public",
+	input: z.object({ value: z.string() }),
+	permission: probePermissions.echo,
+	facts: ({ input }) => ({ value: input.value }),
+	execute: ({ input }) => ({ value: input.value }),
+});
+const backendPlugin = defineBackendPlugin({
+	name: "probe",
+	dbPlugin: createDbPlugin("probe", {}),
+	operations: () => ({ echo: probeOperation }),
+	routes: (_adapter, _context, operations) => ({
+		echo: createEndpoint(
+			"/echo/:value",
+			{ method: "GET", requireRequest: true },
+			operations.echo.route((context) => ({ value: context.params.value })),
+		),
+	}),
+});
+const clientPlugin = defineClientPlugin({
+	name: "probe",
+	routes: () => ({
+		probe: createRoute("/probe", () => ({
+			PageComponent: () => null,
+		})),
+	}),
+	sitemap: () => [{ url: "https://example.com/probe" }],
+});
+
+describe("symmetric stack constructors", () => {
+	it("keeps the legacy constructor names as exact forwarding aliases", () => {
+		expect(stack).toBe(createBackendStack);
+		expect(createStackClient).toBe(createClientStack);
+	});
+
+	for (const [name, factory] of [
+		["canonical", createBackendStack],
+		["temporary alias", stack],
+	] as const) {
+		it(`preserves backend routes and operation surfaces through the ${name} name`, async () => {
+			const backend = factory({
+				basePath: "/api",
+				plugins: { probe: backendPlugin },
+				adapter,
+			});
+
+			const endpointNames = Object.keys(
+				(backend.router as unknown as { endpoints: Record<string, unknown> })
+					.endpoints,
+			);
+			expect(endpointNames).toContain("probe_echo");
+			await expect(
+				backend.internal.probe.echo({ value: "internal" }),
+			).resolves.toEqual({ value: "internal" });
+			await expect(
+				backend
+					.forRequest(new Request("https://example.com/api"))
+					.api.probe.echo({ value: "request" }),
+			).resolves.toEqual({ value: "request" });
+
+			const response = await backend.handler(
+				new Request("https://example.com/api/echo/handler"),
+			);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ value: "handler" });
+		});
+	}
+
+	for (const [name, factory] of [
+		["canonical", createClientStack],
+		["temporary alias", createStackClient],
+	] as const) {
+		it(`preserves client routes and sitemap behavior through the ${name} name`, async () => {
+			const client = factory({ plugins: { probe: clientPlugin } });
+
+			expect(typeof client.router.getRoute("/probe")?.PageComponent).toBe(
+				"function",
+			);
+			await expect(client.generateSitemap()).resolves.toEqual([
+				{ url: "https://example.com/probe" },
+			]);
+		});
+	}
+});

--- a/packages/stack/src/__tests__/stack-constructors.typecheck.ts
+++ b/packages/stack/src/__tests__/stack-constructors.typecheck.ts
@@ -89,6 +89,12 @@ type _BackendFactoriesMatch = Expect<
 type _BackendInferenceMatches = Expect<
 	Equal<typeof canonicalBackend, typeof temporaryBackend>
 >;
+type _CanonicalBackendRouteKeys = Expect<
+	Equal<keyof typeof canonicalBackend.router.endpoints, "constructorProbe_read">
+>;
+type _TemporaryBackendRouteKeys = Expect<
+	Equal<keyof typeof temporaryBackend.router.endpoints, "constructorProbe_read">
+>;
 const canonicalBackendConfig: BackendStackConfig = backendConfig;
 const legacyBackendConfig: BackendLibConfig = canonicalBackendConfig;
 const canonicalBackendResult: BackendStack = canonicalBackend;

--- a/packages/stack/src/__tests__/stack-constructors.typecheck.ts
+++ b/packages/stack/src/__tests__/stack-constructors.typecheck.ts
@@ -1,0 +1,151 @@
+import { createMemoryAdapter } from "@btst/adapter-memory";
+import { createDbPlugin, type DatabaseDefinition } from "@btst/db";
+import { createRoute } from "@btst/yar";
+import { z } from "zod";
+import {
+	createBackendStack,
+	stack,
+	type BackendLib,
+	type BackendLibConfig,
+	type BackendStack,
+	type BackendStackConfig,
+} from "../api";
+import {
+	defineAuthorization,
+	definePermissions,
+	permission,
+} from "../authorization";
+import { createServerAuth } from "../authorization/server";
+import {
+	createClientStack,
+	createStackClient,
+	type ClientLib,
+	type ClientLibConfig,
+	type ClientStack,
+	type ClientStackConfig,
+} from "../client";
+import {
+	createEndpoint,
+	defineBackendPlugin,
+	defineOperation,
+} from "../plugins/api";
+import { defineClientPlugin } from "../plugins/client";
+
+type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <
+	T,
+>() => T extends TRight ? 1 : 2
+	? true
+	: false;
+type Expect<T extends true> = T;
+
+const permissions = definePermissions("constructorProbe", {
+	read: permission(z.object({ id: z.string() })),
+});
+const authorization = defineAuthorization({
+	identity: z.object({ id: z.string() }),
+	permissions: [permissions] as const,
+	rules: ({ constructorProbe }) => [constructorProbe.read.allow()],
+});
+const serverAuth = createServerAuth({
+	authorization,
+	getIdentity: () => ({ id: "user-1" }),
+});
+const read = defineOperation({
+	input: z.object({ id: z.string() }),
+	permission: permissions.read,
+	facts: ({ input }) => ({ id: input.id }),
+	execute: ({ input }) => ({ id: input.id }),
+});
+const backendPlugin = defineBackendPlugin({
+	name: "constructorProbe",
+	dbPlugin: createDbPlugin("constructorProbe", {}),
+	operations: () => ({ read }),
+	routes: (_adapter, _context, operations) => ({
+		read: createEndpoint(
+			"/constructor-probe/:id",
+			{ method: "GET", requireRequest: true },
+			operations.read.route((context) => ({ id: context.params.id })),
+		),
+	}),
+});
+const backendConfig = {
+	basePath: "/api",
+	plugins: { constructorProbe: backendPlugin },
+	adapter: (db: DatabaseDefinition) => createMemoryAdapter(db)({}),
+	auth: serverAuth,
+} satisfies BackendStackConfig<
+	{ constructorProbe: typeof backendPlugin },
+	typeof serverAuth
+>;
+
+const canonicalBackend = createBackendStack(backendConfig);
+const temporaryBackend = stack(backendConfig);
+type _BackendFactoriesMatch = Expect<
+	Equal<typeof createBackendStack, typeof stack>
+>;
+type _BackendInferenceMatches = Expect<
+	Equal<typeof canonicalBackend, typeof temporaryBackend>
+>;
+const canonicalBackendConfig: BackendStackConfig = backendConfig;
+const legacyBackendConfig: BackendLibConfig = canonicalBackendConfig;
+const canonicalBackendResult: BackendStack = canonicalBackend;
+const legacyBackendResult: BackendLib = canonicalBackendResult;
+void legacyBackendConfig;
+void legacyBackendResult;
+canonicalBackend.internal.constructorProbe.read({ id: "record-1" });
+canonicalBackend
+	.forRequest(new Request("https://example.com/api"))
+	.api.constructorProbe.read({ id: "record-1" });
+
+const unrelatedPermissions = definePermissions("unrelated", {
+	read: permission(),
+});
+const incompatibleAuth = createServerAuth({
+	authorization: defineAuthorization({
+		identity: z.object({ id: z.string() }),
+		permissions: [unrelatedPermissions] as const,
+		rules: ({ unrelated }) => [unrelated.read.allow()],
+	}),
+	getIdentity: () => ({ id: "user-1" }),
+});
+createBackendStack({
+	...backendConfig,
+	// @ts-expect-error canonical constructor rejects incompatible authorization catalogs
+	auth: incompatibleAuth,
+});
+stack({
+	...backendConfig,
+	// @ts-expect-error temporary alias preserves authorization compatibility inference
+	auth: incompatibleAuth,
+});
+
+const clientPlugin = defineClientPlugin({
+	name: "constructorProbe",
+	routes: () => ({
+		read: createRoute("/constructor-probe/:id", ({ params }) => ({
+			PageComponent: () => null,
+			loader: async () => ({ recordId: params.id }),
+		})),
+	}),
+});
+const clientConfig = {
+	plugins: { constructorProbe: clientPlugin },
+} satisfies ClientStackConfig<{ constructorProbe: typeof clientPlugin }>;
+const canonicalClient = createClientStack(clientConfig);
+const temporaryClient = createStackClient(clientConfig);
+type _ClientFactoriesMatch = Expect<
+	Equal<typeof createClientStack, typeof createStackClient>
+>;
+type _ClientInferenceMatches = Expect<
+	Equal<typeof canonicalClient, typeof temporaryClient>
+>;
+const canonicalClientConfig: ClientStackConfig = clientConfig;
+const legacyClientConfig: ClientLibConfig = canonicalClientConfig;
+const canonicalClientResult: ClientStack<
+	ReturnType<typeof clientPlugin.routes>
+> = canonicalClient;
+const legacyClientResult: ClientLib<ReturnType<typeof clientPlugin.routes>> =
+	canonicalClientResult;
+void legacyClientConfig;
+void legacyClientResult;
+canonicalClient.router.getRoute("/constructor-probe/record-1")?.loader?.();

--- a/packages/stack/src/__tests__/stack-constructors.typecheck.ts
+++ b/packages/stack/src/__tests__/stack-constructors.typecheck.ts
@@ -1,5 +1,8 @@
-import { createMemoryAdapter } from "@btst/adapter-memory";
-import { createDbPlugin, type DatabaseDefinition } from "@btst/db";
+import {
+	createDbPlugin,
+	type DatabaseDefinition,
+	type DBAdapter,
+} from "@btst/db";
 import { createRoute } from "@btst/yar";
 import { z } from "zod";
 import {
@@ -71,7 +74,7 @@ const backendPlugin = defineBackendPlugin({
 const backendConfig = {
 	basePath: "/api",
 	plugins: { constructorProbe: backendPlugin },
-	adapter: (db: DatabaseDefinition) => createMemoryAdapter(db)({}),
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
 	auth: serverAuth,
 } satisfies BackendStackConfig<
 	{ constructorProbe: typeof backendPlugin },

--- a/packages/stack/src/api/index.ts
+++ b/packages/stack/src/api/index.ts
@@ -1,7 +1,7 @@
 import { createRouter } from "better-call";
 import type {
-	BackendLibConfig,
-	BackendLib,
+	BackendStackConfig,
+	BackendStack,
 	PrefixedPluginRoutes,
 	PluginApis,
 	PluginOperations,
@@ -67,11 +67,11 @@ function throwHttpOperationError(
 }
 
 /**
- * Creates the backend library with plugin support
+ * Creates the backend stack with plugin support
  *
  * @example
  * ```ts
- * const api = stack({
+ * const api = createBackendStack({
  *   plugins: {
  *     messages: messagesPlugin.backend
  *   },
@@ -86,23 +86,23 @@ function throwHttpOperationError(
  * @template TPlugins - The exact plugins map (inferred from config)
  * @template TRoutes - All routes with prefixed keys like "pluginName_routeName" (computed automatically)
  */
-export function stack<
+export function createBackendStack<
 	const TPlugins extends Record<string, BackendPlugin<any, any, any>>,
 	const TAuth extends ServerAuth<AnyAuthorization> | undefined,
 	TRoutes extends
 		PrefixedPluginRoutes<TPlugins> = PrefixedPluginRoutes<TPlugins>,
 >(
-	config: BackendLibConfig<TPlugins, TAuth> & {
+	config: BackendStackConfig<TPlugins, TAuth> & {
 		auth?: CompatibleStackAuth<TPlugins, TAuth>;
 	},
-): BackendLib<TRoutes, PluginApis<TPlugins>, PluginOperations<TPlugins>> {
+): BackendStack<TRoutes, PluginApis<TPlugins>, PluginOperations<TPlugins>> {
 	const { plugins, adapter, dbSchema, basePath } = config;
 	const runtimeAuth = (
 		config as unknown as { auth?: ServerAuth<AnyAuthorization> }
 	).auth;
 	if (runtimeAuth && !isServerAuth(runtimeAuth)) {
 		throw new TypeError(
-			"stack({ auth }) requires an adapter created by createServerAuth().",
+			"createBackendStack({ auth }) requires an adapter created by createServerAuth().",
 		);
 	}
 
@@ -270,8 +270,15 @@ export function stack<
 	};
 }
 
+/**
+ * @deprecated Use `createBackendStack`. This alias is removed by #225.
+ */
+export const stack: typeof createBackendStack = createBackendStack;
+
 export type {
 	BackendPlugin,
+	BackendStackConfig,
+	BackendStack,
 	BackendLibConfig,
 	BackendLib,
 	PluginApis,

--- a/packages/stack/src/client/index.ts
+++ b/packages/stack/src/client/index.ts
@@ -1,8 +1,8 @@
 import { createRouter } from "@btst/yar";
 
 import type {
-	ClientLibConfig,
-	ClientLib,
+	ClientStackConfig,
+	ClientStack,
 	ClientPlugin,
 	ClientStackContext,
 	PluginRoutes,
@@ -11,12 +11,12 @@ import type {
 export type { ClientPlugin, ClientStackContext } from "../types";
 
 /**
- * Creates the client library with plugin support
+ * Creates the client stack with plugin support
  *
  * @example
  * ```ts
  * // For Next.js with SSR:
- * const lib = createStackClient({
+ * const lib = createClientStack({
  *   plugins: {
  *     blog: blogPlugin.client
  *   }
@@ -57,10 +57,10 @@ export type { ClientPlugin, ClientStackContext } from "../types";
  * @template TPlugins - The exact plugins map (inferred from config)
  * @template TRoutes - All routes from all plugins, merged (computed automatically)
  */
-export function createStackClient<
+export function createClientStack<
 	TPlugins extends Record<string, ClientPlugin<any, any>>,
 	TRoutes extends PluginRoutes<TPlugins> = PluginRoutes<TPlugins>,
->(config: ClientLibConfig<TPlugins>): ClientLib<TRoutes> {
+>(config: ClientStackConfig<TPlugins>): ClientStack<TRoutes> {
 	const { plugins, basePath } = config;
 
 	// Collect all routes from all plugins
@@ -107,7 +107,17 @@ export function createStackClient<
 	};
 }
 
-export type { ClientLib, ClientLibConfig };
+/**
+ * @deprecated Use `createClientStack`. This alias is removed by #225.
+ */
+export const createStackClient: typeof createClientStack = createClientStack;
+
+export type {
+	ClientStack,
+	ClientStackConfig,
+	ClientLib,
+	ClientLibConfig,
+} from "../types";
 
 export { sitemapEntryToXmlString } from "./sitemap-utils";
 

--- a/packages/stack/src/types.ts
+++ b/packages/stack/src/types.ts
@@ -380,7 +380,7 @@ export interface BackendStack<
 	> = Record<string, Record<string, (...args: any[]) => any>>,
 > {
 	handler: (request: Request) => Promise<Response>; // API route handler
-	router: Router; // Better-call router
+	router: Omit<Router, "endpoints"> & { endpoints: TRoutes }; // Better-call router
 	dbSchema: DatabaseDefinition; // Better-db schema
 	/** The database adapter shared across all plugins */
 	adapter: Adapter;

--- a/packages/stack/src/types.ts
+++ b/packages/stack/src/types.ts
@@ -37,7 +37,7 @@ export interface StackContext {
 	basePath: string;
 	/** The database adapter */
 	adapter: Adapter;
-	/** The server-side auth provider, when configured on `stack()` */
+	/** The server-side auth provider, when configured on `createBackendStack()` */
 	auth?: ServerAuth<AnyAuthorization>;
 	/** Routes already constructed for each plugin, used by introspection plugins. */
 	pluginRoutes: Record<string, Record<string, Endpoint>>;
@@ -70,9 +70,9 @@ export interface ClientStackContext<
  * You can optionally provide a base schema via the dbSchema config option.
  *
  * @template TRoutes - The exact shape of routes this plugin provides (preserves keys and endpoint types)
- * @template TApi - The shape of the server-side API surface exposed via `stack().api`.
+ * @template TApi - The shape of the server-side API surface exposed via `createBackendStack().api`.
  *   Defaults to `never` so that plugins without an `api` factory are excluded from the
- *   `stack().api` namespace entirely, preventing accidental access of `undefined` at runtime.
+ *   `createBackendStack().api` namespace entirely, preventing accidental access of `undefined` at runtime.
  */
 export interface BackendPlugin<
 	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
@@ -103,7 +103,7 @@ export interface BackendPlugin<
 
 	/**
 	 * Optional factory that returns server-side getter functions bound to the adapter.
-	 * The returned object is merged into `stack().api.<pluginName>.*` for direct
+	 * The returned object is merged into `createBackendStack().api.<pluginName>.*` for direct
 	 * server-side or SSG data access without going through HTTP.
 	 *
 	 * @param adapter - The adapter instance shared with `routes`
@@ -251,9 +251,9 @@ export type CompatibleStackAuth<
 	: TAuth;
 
 /**
- * Configuration for creating the backend library
+ * Configuration for creating the backend stack
  */
-export interface BackendLibConfig<
+export interface BackendStackConfig<
 	TPlugins extends Record<string, BackendPlugin<any, any, any>> = Record<
 		string,
 		BackendPlugin<any, any, any>
@@ -276,9 +276,22 @@ export interface BackendLibConfig<
 }
 
 /**
- * Configuration for creating the client library
+ * @deprecated Use `BackendStackConfig`. This alias is removed by #225.
  */
-export interface ClientLibConfig<
+export type BackendLibConfig<
+	TPlugins extends Record<string, BackendPlugin<any, any, any>> = Record<
+		string,
+		BackendPlugin<any, any, any>
+	>,
+	TAuth extends ServerAuth<AnyAuthorization> | undefined =
+		| ServerAuth<AnyAuthorization>
+		| undefined,
+> = BackendStackConfig<TPlugins, TAuth>;
+
+/**
+ * Configuration for creating the client stack
+ */
+export interface ClientStackConfig<
 	TPlugins extends Record<string, ClientPlugin<any, any>> = Record<
 		string,
 		ClientPlugin<any, any>
@@ -288,6 +301,16 @@ export interface ClientLibConfig<
 	baseURL?: string;
 	basePath?: string;
 }
+
+/**
+ * @deprecated Use `ClientStackConfig`. This alias is removed by #225.
+ */
+export type ClientLibConfig<
+	TPlugins extends Record<string, ClientPlugin<any, any>> = Record<
+		string,
+		ClientPlugin<any, any>
+	>,
+> = ClientStackConfig<TPlugins>;
 
 /**
  * Utility type to extract override types from plugins
@@ -343,9 +366,9 @@ export type PrefixedPluginRoutes<
 	: Record<string, Endpoint>;
 
 /**
- * Result of creating the backend library
+ * Result of creating the backend stack
  */
-export interface BackendLib<
+export interface BackendStack<
 	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
 	TApis extends Record<
 		string,
@@ -368,6 +391,21 @@ export interface BackendLib<
 	/** Trusted operations that retain validation and lifecycle hooks. */
 	internal: TOperations;
 }
+
+/**
+ * @deprecated Use `BackendStack`. This alias is removed by #225.
+ */
+export type BackendLib<
+	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
+	TApis extends Record<
+		string,
+		Record<string, (...args: any[]) => any>
+	> = Record<string, Record<string, (...args: any[]) => any>>,
+	TOperations extends Record<
+		string,
+		Record<string, (...args: any[]) => any>
+	> = Record<string, Record<string, (...args: any[]) => any>>,
+> = BackendStack<TRoutes, TApis, TOperations>;
 
 /**
  * Helper type to extract routes from a client plugin
@@ -403,14 +441,21 @@ type UnionToIntersection<U> = (
 	: never;
 
 /**
- * Result of creating the client library
+ * Result of creating the client stack
  */
-export interface ClientLib<
+export interface ClientStack<
 	TRoutes extends Record<string, Route> = Record<string, Route>,
 > {
 	router: ReturnType<typeof createRouter<TRoutes, {}>>;
 	generateSitemap: () => Promise<Sitemap>;
 }
+
+/**
+ * @deprecated Use `ClientStack`. This alias is removed by #225.
+ */
+export type ClientLib<
+	TRoutes extends Record<string, Route> = Record<string, Route>,
+> = ClientStack<TRoutes>;
 
 /**
  * Minimal sitemap entry shape aligned with Next.js MetadataRoute.Sitemap


### PR DESCRIPTION
## Summary

- Adds createBackendStack and createClientStack as the canonical, symmetric constructor names.
- Makes BackendStackConfig, BackendStack, ClientStackConfig, and ClientStack the canonical declaration vocabulary.
- Retains stack, createStackClient, and the legacy Lib type names as exact deprecated forwarding aliases scheduled for removal by #225.
- Preserves backend authorization, endpoint inventory, request/internal operations, client routes, and sitemap runtime behavior.
- Adds runtime, compile-time, ESM, CJS, declaration, and public package-resolution coverage.

## Authorization and compatibility

No authorization logic or lifecycle ordering changed. The canonical backend constructor retains compatible authorization catalog inference, optional-auth permissive behavior, authoritative enabled auth, and the existing request/internal boundary. Both temporary constructors are the exact same function objects as their canonical replacements.

## Verification

- pnpm --filter @btst/stack build
- pnpm --filter @btst/stack typecheck
- pnpm --filter @btst/stack test --run (69 files, 880 tests)
- pnpm lint
- public consumer TypeScript fixture through @btst/stack/api and @btst/stack/client
- built ESM and CJS package resolution

Maintained docs, generated apps, and plugin examples are intentionally unchanged in this expansion slice; #224 owns canonical documentation and #225 owns alias contraction.

Closes #208