### PR TITLE
feat(stack): infer plugin IDs and provider overrides

### DIFF
--- a/packages/stack/consumer-tests/client-runtime/index.ts
+++ b/packages/stack/consumer-tests/client-runtime/index.ts
@@ -1,15 +1,28 @@
 import { QueryClient } from "@tanstack/react-query";
+import type { DatabaseDefinition, DBAdapter } from "@btst/db";
+import { createBackendStack } from "@btst/stack/api";
 import {
 	createClientStack,
 	type ResolvedClientPluginRuntime,
 } from "@btst/stack/client";
 import { createRoute, defineClientPlugin } from "@btst/stack/plugins/client";
+import {
+	createDbPlugin,
+	createEndpoint,
+	defineBackendPlugin,
+} from "@btst/stack/plugins/api";
+
+export interface ConsumerProbeOverrides {
+	label: string;
+	format?: "short" | "long";
+}
 
 const observations: ResolvedClientPluginRuntime[] = [];
 const probeClientPlugin = () =>
-	defineClientPlugin({
-		name: "consumerProbe",
+	defineClientPlugin<ConsumerProbeOverrides>()({
+		id: "consumerProbe",
 		resolve(runtime) {
+			runtime.id satisfies "consumerProbe";
 			observations.push(runtime);
 			return {
 				routes: () => ({
@@ -39,6 +52,8 @@ const probeClientPlugin = () =>
 		},
 	});
 
+probeClientPlugin().id satisfies "consumerProbe";
+
 const queryClient = new QueryClient();
 const clientStack = createClientStack({
 	api: {
@@ -64,7 +79,7 @@ const clientStack = createClientStack({
 	},
 });
 
-const browserClientStack = createClientStack({
+export const browserClientStack = createClientStack({
 	api: {
 		baseURL: "https://app.example.com",
 		basePath: "/api/data",
@@ -88,6 +103,7 @@ const browserClientStack = createClientStack({
 });
 
 clientStack.provider.queryClient satisfies QueryClient;
+clientStack.provider.plugins.consumerProbe.id satisfies "consumerProbe";
 clientStack.provider.plugins.consumerProbe.api.basePath satisfies string;
 browserClientStack.provider.queryClient satisfies QueryClient;
 browserClientStack.provider.plugins.consumerProbe.api.basePath satisfies string;
@@ -95,6 +111,7 @@ browserClientStack.provider.plugins.consumerProbe.api.browserHeaders satisfies
 	| Headers
 	| undefined;
 observations[0]?.api.headers satisfies Headers | undefined;
+observations[0]?.id satisfies string | undefined;
 // @ts-expect-error Request headers do not exist on the top-level provider projection.
 clientStack.provider.api.headers;
 
@@ -109,6 +126,44 @@ createClientStack({
 			api: { baseURL: "https://plugins.example.net" },
 		},
 	},
+});
+
+createClientStack({
+	api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+	site: { baseURL: "https://app.example.com", basePath: "/pages" },
+	queryClient,
+	plugins: {
+		// @ts-expect-error Registration aliases cannot diverge from a canonical ID.
+		alias: probeClientPlugin(),
+	},
+});
+
+const probeBackendPlugin = () =>
+	defineBackendPlugin({
+		id: "consumerProbe",
+		dbPlugin: createDbPlugin("consumer-probe", {}),
+		routes: () => ({
+			probe: createEndpoint("/probe", { method: "GET" }, async () => ({
+				ok: true,
+			})),
+		}),
+	});
+
+probeBackendPlugin().id satisfies "consumerProbe";
+
+createBackendStack({
+	basePath: "/api/data",
+	plugins: { consumerProbe: probeBackendPlugin() },
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
+});
+
+createBackendStack({
+	basePath: "/api/data",
+	plugins: {
+		// @ts-expect-error Backend registration aliases cannot diverge from a canonical ID.
+		alias: probeBackendPlugin(),
+	},
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
 });
 
 createClientStack({

--- a/packages/stack/consumer-tests/client-runtime/provider.tsx
+++ b/packages/stack/consumer-tests/client-runtime/provider.tsx
@@ -1,0 +1,21 @@
+import { StackProvider } from "@btst/stack/context";
+import { browserClientStack } from "./index";
+
+<StackProvider
+	stack={browserClientStack}
+	overrides={{ consumerProbe: { label: "Consumer", format: "short" } }}
+/>;
+
+<StackProvider stack={browserClientStack} />;
+
+// @ts-expect-error Override values are inferred from the registered plugin factory.
+<StackProvider
+	stack={browserClientStack}
+	overrides={{ consumerProbe: { label: "Consumer", format: "wide" } }}
+/>;
+
+// @ts-expect-error Unknown plugins are not valid provider override keys.
+<StackProvider
+	stack={browserClientStack}
+	overrides={{ missing: { label: "Missing" } }}
+/>;

--- a/packages/stack/consumer-tests/client-runtime/tsconfig.json
+++ b/packages/stack/consumer-tests/client-runtime/tsconfig.json
@@ -4,10 +4,14 @@
     "baseUrl": ".",
     "incremental": false,
     "noEmit": true,
+    "jsx": "react-jsx",
     "paths": {
       "@btst/stack/client": ["../../src/client/index.ts"],
+      "@btst/stack/context": ["../../src/context/index.ts"],
+      "@btst/stack/api": ["../../src/api/index.ts"],
+      "@btst/stack/plugins/api": ["../../src/plugins/api/index.ts"],
       "@btst/stack/plugins/client": ["../../src/plugins/client/index.ts"]
     }
   },
-  "include": ["./index.ts"]
+  "include": ["./index.ts", "./provider.tsx"]
 }

--- a/packages/stack/src/__tests__/client-runtime.test.ts
+++ b/packages/stack/src/__tests__/client-runtime.test.ts
@@ -224,6 +224,7 @@ describe("resolved client runtime", () => {
 			basePath: "/pages",
 		});
 		expect(stack.provider.plugins.probe).toEqual({
+			id: "probe",
 			api: {
 				baseURL: "https://app.example.com",
 				basePath: "/api/data",
@@ -337,6 +338,7 @@ describe("resolved client runtime", () => {
 			basePath: "/features",
 		});
 		expect(stack.provider.plugins.probe).toEqual({
+			id: "probe",
 			api: {
 				baseURL: "https://plugins.example.net",
 				basePath: "/btst/probe",
@@ -721,6 +723,7 @@ describe("resolved client runtime", () => {
 			endpoints: { probe: {} },
 		});
 		expect(inherited.provider.plugins.probe).toEqual({
+			id: "probe",
 			api: baseConfig.api,
 			site: baseConfig.site,
 		});

--- a/packages/stack/src/__tests__/initial-identity-hydration.test.tsx
+++ b/packages/stack/src/__tests__/initial-identity-hydration.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act } from "react";
+import { QueryClient } from "@tanstack/react-query";
 import { hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ import {
 	permission,
 } from "../authorization";
 import { createClientAuth } from "../authorization/client";
+import { createClientStack } from "../client";
 import { StackProvider } from "../context";
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -28,6 +30,13 @@ const authorization = defineAuthorization({
 	],
 });
 
+const clientStack = createClientStack({
+	api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+	site: { baseURL: "https://app.example.com", basePath: "/pages" },
+	queryClient: new QueryClient(),
+	plugins: {},
+});
+
 let container: HTMLDivElement;
 let root: Root | undefined;
 
@@ -44,6 +53,34 @@ afterEach(async () => {
 });
 
 describe("initial identity SSR hydration", () => {
+	it("keeps an unsupplied snapshot pending while the browser resolver runs", async () => {
+		const getIdentity = vi.fn(() => new Promise<never>(() => {}));
+		const clientAuth = createClientAuth({ authorization, getIdentity });
+		const ui = (
+			<StackProvider stack={clientStack} auth={clientAuth}>
+				<clientAuth.CanAccess
+					permission={permissions.delete({ id: "document-1" })}
+					loading={<span>Checking</span>}
+					fallback={<span>No access</span>}
+				>
+					<button type="button">Delete</button>
+				</clientAuth.CanAccess>
+			</StackProvider>
+		);
+
+		const serverHtml = renderToString(ui);
+		expect(serverHtml).toContain("Checking");
+		expect(getIdentity).not.toHaveBeenCalled();
+
+		container.innerHTML = serverHtml;
+		await act(async () => {
+			root = hydrateRoot(container, ui);
+		});
+
+		expect(container.textContent).toBe("Checking");
+		expect(getIdentity).toHaveBeenCalledOnce();
+	});
+
 	it("keeps authenticated gated UI stable and skips a duplicate browser identity request", async () => {
 		const getIdentity = vi.fn(() => ({
 			id: "browser-user",
@@ -52,7 +89,7 @@ describe("initial identity SSR hydration", () => {
 		const clientAuth = createClientAuth({ authorization, getIdentity });
 		const ui = (
 			<StackProvider
-				basePath="/pages"
+				stack={clientStack}
 				auth={clientAuth}
 				initialIdentity={{ id: "server-user", role: "admin" }}
 			>
@@ -91,7 +128,11 @@ describe("initial identity SSR hydration", () => {
 		}));
 		const clientAuth = createClientAuth({ authorization, getIdentity });
 		const ui = (
-			<StackProvider basePath="/pages" auth={clientAuth} initialIdentity={null}>
+			<StackProvider
+				stack={clientStack}
+				auth={clientAuth}
+				initialIdentity={null}
+			>
 				<clientAuth.CanAccess
 					permission={permissions.delete({ id: "document-1" })}
 					loading={<span>Checking</span>}

--- a/packages/stack/src/__tests__/package-metadata.test.ts
+++ b/packages/stack/src/__tests__/package-metadata.test.ts
@@ -3,7 +3,10 @@ import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
+import { createMemoryAdapter } from "@btst/adapter-memory";
+import type { DatabaseDefinition } from "@btst/db";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 const execFileAsync = promisify(execFile);
 
@@ -149,5 +152,88 @@ describe("published symmetric stack constructors", () => {
 			],
 			{ cwd: resolve(".") },
 		);
+	}, 30_000);
+
+	it("preserves prototype-like canonical IDs across public backend surfaces", async () => {
+		const apiSpecifier = "@btst/stack/api";
+		const pluginApiSpecifier = "@btst/stack/plugins/api";
+		const authorizationSpecifier = "@btst/stack/authorization";
+		const [{ createBackendStack }, pluginApi, authorization] =
+			await Promise.all([
+				import(apiSpecifier),
+				import(pluginApiSpecifier),
+				import(authorizationSpecifier),
+			]);
+		const permissions = authorization.definePermissions("prototype-id", {
+			echo: authorization.permission(),
+		});
+		const echo = pluginApi.defineOperation({
+			access: "public",
+			input: z.object({ value: z.string() }),
+			permission: permissions.echo,
+			facts: () => undefined,
+			execute: ({ input }: { input: { value: string } }) => input.value,
+		});
+		let observedContext:
+			| {
+					pluginRoutes: Record<string, Record<string, unknown>>;
+					endpointInventory?: Array<{ pluginName: string }>;
+			  }
+			| undefined;
+		let observedRouteOperations: Record<string, unknown> | undefined;
+		const prototypePlugin = pluginApi.defineBackendPlugin({
+			id: "__proto__",
+			name: "legacy-name",
+			dbPlugin: pluginApi.createDbPlugin("prototype-id-db", {}),
+			operations: () => ({ echo }),
+			infrastructureRoutes: {
+				health: {
+					access: "public",
+					rationale: "Exercises public stack composition in the package test.",
+				},
+			},
+			routes: (
+				_adapter: unknown,
+				context: typeof observedContext,
+				operations: Record<string, any>,
+			) => {
+				observedContext = context;
+				observedRouteOperations = operations;
+				return {
+					health: pluginApi.createEndpoint(
+						"/prototype-id",
+						{ method: "GET" },
+						async () => ({ ok: true }),
+					),
+				};
+			},
+			api: () => ({ id: () => "__proto__" }),
+		});
+		const registrations: Record<string, unknown> = {
+			["__proto__"]: prototypePlugin,
+		};
+
+		const stack = createBackendStack({
+			plugins: registrations,
+			adapter: (db: DatabaseDefinition) => createMemoryAdapter(db)({}),
+		});
+		const requestApi = stack.forRequest(
+			new Request("https://app.example.com/api"),
+		).api;
+
+		expect(Object.getPrototypeOf(stack.api)).toBeNull();
+		expect(Object.hasOwn(stack.api, "__proto__")).toBe(true);
+		expect(stack.api.__proto__.id()).toBe("__proto__");
+		expect(Object.getPrototypeOf(stack.internal)).toBeNull();
+		expect(Object.getPrototypeOf(stack.internal.__proto__)).toBeNull();
+		expect(Object.getPrototypeOf(requestApi)).toBeNull();
+		expect(Object.getPrototypeOf(requestApi.__proto__)).toBeNull();
+		expect(Object.getPrototypeOf(observedContext?.pluginRoutes)).toBeNull();
+		expect(Object.getPrototypeOf(observedRouteOperations)).toBeNull();
+		expect(observedContext?.endpointInventory?.[0]?.pluginName).toBe(
+			"__proto__",
+		);
+		expect(stack.internal.__proto__.echo).toBeTypeOf("function");
+		expect(requestApi.__proto__.echo).toBeTypeOf("function");
 	}, 30_000);
 });

--- a/packages/stack/src/__tests__/plugin-registration.test.tsx
+++ b/packages/stack/src/__tests__/plugin-registration.test.tsx
@@ -8,6 +8,7 @@ import { createClientStack } from "../client";
 import { StackProvider, usePluginOverrides, useStack } from "../context";
 import { createDbPlugin, defineBackendPlugin } from "../plugins/api";
 import { createRoute, defineClientPlugin } from "../plugins/client";
+import { generateRouteDocsSchema } from "../plugins/route-docs/generator";
 
 function runtimeConfig<TPlugins extends Record<string, any>>(
 	plugins: TPlugins,
@@ -58,6 +59,21 @@ describe("canonical plugin registration IDs", () => {
 				}) as any,
 			),
 		).toThrowError(/client.*ID.*duplicate.*first.*second/i);
+	});
+
+	it("requires plugins to be an own client configuration property", () => {
+		const inheritedConfig = Object.assign(
+			Object.create({ plugins: { probe: identifiedClient("probe") } }),
+			{
+				api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+				site: { baseURL: "https://app.example.com", basePath: "/pages" },
+				queryClient: new QueryClient(),
+			},
+		);
+
+		expect(() => createClientStack(inheritedConfig as any)).toThrowError(
+			/plugins.*registration map/i,
+		);
 	});
 
 	it("rejects backend aliases and duplicate resolved IDs before adapter creation", () => {
@@ -135,6 +151,44 @@ describe("canonical plugin registration IDs", () => {
 		});
 		await expect(stack.generateSitemap()).resolves.toEqual([
 			{ url: "https://app.example.com/pages/probe" },
+		]);
+	});
+
+	it("uses a canonical ID instead of a conflicting legacy name in client diagnostics", () => {
+		let contextPluginName: string | undefined;
+		const canonicalDefinition = defineClientPlugin({
+			id: "canonical",
+			name: "legacy-name",
+			resolve: () => ({
+				routes: (context) => {
+					contextPluginName = context?.plugins.canonical?.name;
+					return {
+						canonical: createRoute("/canonical", () => ({
+							PageComponent: () => null,
+						})),
+					};
+				},
+			}),
+		});
+
+		createClientStack(runtimeConfig({ canonical: canonicalDefinition }));
+
+		expect(contextPluginName).toBe("canonical");
+		const schema = generateRouteDocsSchema({
+			plugins: {
+				canonical: defineClientPlugin({
+					id: "canonical",
+					name: "legacy-name",
+					routes: () => ({
+						canonical: createRoute("/canonical", () => ({
+							PageComponent: () => null,
+						})),
+					}),
+				}),
+			},
+		});
+		expect(schema.plugins).toMatchObject([
+			{ key: "canonical", name: "canonical" },
 		]);
 	});
 });

--- a/packages/stack/src/__tests__/plugin-registration.test.tsx
+++ b/packages/stack/src/__tests__/plugin-registration.test.tsx
@@ -1,0 +1,140 @@
+import { createMemoryAdapter } from "@btst/adapter-memory";
+import { defineDb } from "@btst/db";
+import { QueryClient } from "@tanstack/react-query";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { createBackendStack } from "../api";
+import { createClientStack } from "../client";
+import { StackProvider, usePluginOverrides, useStack } from "../context";
+import { createDbPlugin, defineBackendPlugin } from "../plugins/api";
+import { createRoute, defineClientPlugin } from "../plugins/client";
+
+function runtimeConfig<TPlugins extends Record<string, any>>(
+	plugins: TPlugins,
+) {
+	return {
+		api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+		site: { baseURL: "https://app.example.com", basePath: "/pages" },
+		queryClient: new QueryClient(),
+		plugins,
+	};
+}
+
+function identifiedClient(id: string) {
+	return defineClientPlugin({
+		id,
+		resolve: (runtime) => ({
+			routes: () => ({
+				probe: createRoute(`/${id}`, () => ({ PageComponent: () => null })),
+			}),
+			sitemap: () => [
+				{ url: `${runtime.site.baseURL}${runtime.site.basePath}/${id}` },
+			],
+		}),
+	});
+}
+
+function identifiedBackend(id: string) {
+	return defineBackendPlugin({
+		id,
+		dbPlugin: createDbPlugin(`${id}-db`, {}),
+		routes: () => ({}),
+	});
+}
+
+describe("canonical plugin registration IDs", () => {
+	it("rejects client aliases and duplicate resolved IDs before resolution", () => {
+		expect(() =>
+			createClientStack(
+				runtimeConfig({ alias: identifiedClient("actual") }) as any,
+			),
+		).toThrowError(/client.*key.*alias.*ID.*actual/i);
+
+		expect(() =>
+			createClientStack(
+				runtimeConfig({
+					first: identifiedClient("duplicate"),
+					second: identifiedClient("duplicate"),
+				}) as any,
+			),
+		).toThrowError(/client.*ID.*duplicate.*first.*second/i);
+	});
+
+	it("rejects backend aliases and duplicate resolved IDs before adapter creation", () => {
+		const adapter = vi.fn(() => createMemoryAdapter(defineDb({}))({}));
+		expect(() =>
+			createBackendStack({
+				basePath: "/api/data",
+				plugins: { alias: identifiedBackend("actual") },
+				adapter,
+			} as any),
+		).toThrowError(/backend.*key.*alias.*ID.*actual/i);
+		expect(adapter).not.toHaveBeenCalled();
+
+		expect(() =>
+			createBackendStack({
+				basePath: "/api/data",
+				plugins: {
+					first: identifiedBackend("duplicate"),
+					second: identifiedBackend("duplicate"),
+				},
+				adapter,
+			} as any),
+		).toThrowError(/backend.*ID.*duplicate.*first.*second/i);
+		expect(adapter).not.toHaveBeenCalled();
+	});
+
+	it("binds provider runtime and overrides to the resolved client stack", async () => {
+		const plugin = defineClientPlugin<{ label: string }>()({
+			id: "probe",
+			resolve: (runtime) => ({
+				routes: () => ({
+					probe: createRoute("/probe", () => ({ PageComponent: () => null })),
+				}),
+				sitemap: () => [
+					{ url: `${runtime.site.baseURL}${runtime.site.basePath}/probe` },
+				],
+			}),
+		});
+		const stack = createClientStack({
+			...runtimeConfig({ probe: plugin }),
+			endpoints: { probe: { api: { basePath: "/api/probe" } } },
+		});
+		let observed:
+			| {
+					basePath: string;
+					apiBasePath?: string;
+					pluginBasePath?: string;
+					label: string;
+			  }
+			| undefined;
+
+		function Probe() {
+			const context = useStack();
+			const overrides = usePluginOverrides<{ label: string }>("probe");
+			observed = {
+				basePath: context.basePath,
+				apiBasePath: context.api?.basePath,
+				pluginBasePath: context.plugins?.probe?.api.basePath,
+				label: overrides.label,
+			};
+			return null;
+		}
+
+		renderToString(
+			<StackProvider stack={stack} overrides={{ probe: { label: "Resolved" } }}>
+				<Probe />
+			</StackProvider>,
+		);
+
+		expect(observed).toEqual({
+			basePath: "/pages",
+			apiBasePath: "/api/data",
+			pluginBasePath: "/api/probe",
+			label: "Resolved",
+		});
+		await expect(stack.generateSitemap()).resolves.toEqual([
+			{ url: "https://app.example.com/pages/probe" },
+		]);
+	});
+});

--- a/packages/stack/src/__tests__/plugin-registration.typecheck.tsx
+++ b/packages/stack/src/__tests__/plugin-registration.typecheck.tsx
@@ -1,0 +1,139 @@
+import type { DatabaseDefinition, DBAdapter } from "@btst/db";
+import { QueryClient } from "@tanstack/react-query";
+import { createBackendStack } from "../api";
+import { createClientStack } from "../client";
+import { StackProvider } from "../context";
+import {
+	createDbPlugin,
+	createEndpoint,
+	defineBackendPlugin,
+} from "../plugins/api";
+import { createRoute, defineClientPlugin } from "../plugins/client";
+
+interface ConsumerOverrides {
+	label: string;
+	format?: "short" | "long";
+}
+
+function consumerClientPlugin() {
+	return defineClientPlugin<ConsumerOverrides>()({
+		id: "consumerProbe",
+		resolve: () => ({
+			routes: () => ({
+				consumerProbe: createRoute("/consumer-probe", () => ({
+					PageComponent: () => null,
+				})),
+			}),
+		}),
+	});
+}
+
+function routeOnlyClientPlugin() {
+	return defineClientPlugin({
+		id: "routeOnly",
+		resolve: () => ({
+			routes: () => ({
+				routeOnly: createRoute("/route-only", () => ({
+					PageComponent: () => null,
+				})),
+			}),
+		}),
+	});
+}
+
+consumerClientPlugin().id satisfies "consumerProbe";
+routeOnlyClientPlugin().id satisfies "routeOnly";
+
+const queryClient = new QueryClient();
+const clientStack = createClientStack({
+	api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+	site: { baseURL: "https://app.example.com", basePath: "/pages" },
+	queryClient,
+	plugins: {
+		consumerProbe: consumerClientPlugin(),
+		routeOnly: routeOnlyClientPlugin(),
+	},
+});
+
+const routeOnlyStack = createClientStack({
+	api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+	site: { baseURL: "https://app.example.com", basePath: "/pages" },
+	queryClient,
+	plugins: { routeOnly: routeOnlyClientPlugin() },
+});
+
+<StackProvider
+	stack={clientStack}
+	router={{ navigate: () => undefined }}
+	overrides={{
+		consumerProbe: { label: "Probe", format: "short" },
+	}}
+/>;
+
+<StackProvider stack={clientStack} />;
+
+<StackProvider stack={routeOnlyStack} />;
+
+// @ts-expect-error No-override stacks do not accept activation-style empty blocks.
+<StackProvider stack={routeOnlyStack} overrides={{ routeOnly: {} }} />;
+
+// @ts-expect-error Override values are inferred from the registered definition.
+<StackProvider
+	stack={clientStack}
+	overrides={{
+		consumerProbe: {
+			label: "Probe",
+			format: "wide",
+		},
+	}}
+/>;
+
+// @ts-expect-error Plugins without configurable fields are absent from overrides.
+<StackProvider
+	stack={clientStack}
+	overrides={{
+		routeOnly: {},
+	}}
+/>;
+
+// @ts-expect-error Canonical providers consume API/site paths from the resolved stack.
+<StackProvider stack={clientStack} basePath="/other-pages" />;
+
+createClientStack({
+	api: { baseURL: "https://app.example.com", basePath: "/api/data" },
+	site: { baseURL: "https://app.example.com", basePath: "/pages" },
+	queryClient,
+	plugins: {
+		// @ts-expect-error Registration keys must equal a canonical client plugin ID.
+		alias: consumerClientPlugin(),
+	},
+});
+
+function consumerBackendPlugin() {
+	return defineBackendPlugin({
+		id: "consumerProbe",
+		dbPlugin: createDbPlugin("consumer-probe-db", {}),
+		routes: () => ({
+			probe: createEndpoint("/probe", { method: "GET" }, async () => ({
+				ok: true,
+			})),
+		}),
+	});
+}
+
+consumerBackendPlugin().id satisfies "consumerProbe";
+
+createBackendStack({
+	basePath: "/api/data",
+	plugins: { consumerProbe: consumerBackendPlugin() },
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
+});
+
+createBackendStack({
+	basePath: "/api/data",
+	plugins: {
+		// @ts-expect-error Registration keys must equal a canonical backend plugin ID.
+		alias: consumerBackendPlugin(),
+	},
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
+});

--- a/packages/stack/src/__tests__/plugin-registration.typecheck.tsx
+++ b/packages/stack/src/__tests__/plugin-registration.typecheck.tsx
@@ -1,5 +1,10 @@
 import type { DatabaseDefinition, DBAdapter } from "@btst/db";
 import { QueryClient } from "@tanstack/react-query";
+import type {
+	BackendPlugin,
+	ClientPlugin,
+	ClientPluginDefinition,
+} from "../types";
 import { createBackendStack } from "../api";
 import { createClientStack } from "../client";
 import { StackProvider } from "../context";
@@ -14,6 +19,25 @@ interface ConsumerOverrides {
 	label: string;
 	format?: "short" | "long";
 }
+
+const broadLegacyClient: ClientPlugin<ConsumerOverrides> = {
+	name: "broad-client",
+	routes: () => ({}),
+};
+defineClientPlugin(broadLegacyClient);
+
+const broadLegacyDefinition: ClientPluginDefinition<ConsumerOverrides> = {
+	name: "broad-definition",
+	resolve: () => ({ routes: () => ({}) }),
+};
+defineClientPlugin(broadLegacyDefinition);
+
+const broadLegacyBackend: BackendPlugin = {
+	name: "broad-backend",
+	dbPlugin: createDbPlugin("broad-backend-db", {}),
+	routes: () => ({}),
+};
+defineBackendPlugin(broadLegacyBackend);
 
 function consumerClientPlugin() {
 	return defineClientPlugin<ConsumerOverrides>()({

--- a/packages/stack/src/__tests__/resource-factory.test.tsx
+++ b/packages/stack/src/__tests__/resource-factory.test.tsx
@@ -3,9 +3,11 @@ import { act, Suspense } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createClientStack } from "../client";
 import { StackProvider } from "../context";
 import {
 	createResourceQueryKeys,
+	defineClientPlugin,
 	runResourceMutation,
 	type ResourcesDeclaration,
 	type StackError,
@@ -380,6 +382,64 @@ describe("createResource hooks", () => {
 		const url = String(fetchMock.mock.calls[0]?.[0]);
 		expect(url).toContain("http://test.local/api/data/items");
 		expect(url).toContain("id=1");
+	});
+
+	it("resolves a resource through its registration-bound provider runtime", async () => {
+		fetchMock.mockResolvedValue(
+			jsonResponse({ items: [{ id: "1", name: "canonical" }] }),
+		);
+		let canonicalItems!: typeof items;
+		const stack = createClientStack({
+			api: { baseURL: "http://test.local", basePath: "/api/data" },
+			site: { baseURL: "http://test.local", basePath: "/pages" },
+			queryClient,
+			plugins: {
+				canonicalProbe: defineClientPlugin({
+					id: "canonicalProbe",
+					resolve: (runtime) => {
+						canonicalItems = createResource({
+							plugin: runtime.id,
+							resources,
+						});
+						return { routes: () => ({}) };
+					},
+				}),
+			},
+			endpoints: {
+				canonicalProbe: {
+					api: {
+						basePath: "/api/canonical",
+						browserHeaders: { "x-canonical": "bound" },
+						credentials: "include",
+					},
+				},
+			},
+		});
+
+		let captured: any;
+		function Probe() {
+			captured = canonicalItems.items.detail.use(["1"]);
+			return null;
+		}
+		await act(async () => {
+			root.render(
+				<StackProvider stack={stack} router={{ refresh }}>
+					<QueryClientProvider client={stack.provider.queryClient}>
+						<Probe />
+					</QueryClientProvider>
+				</StackProvider>,
+			);
+		});
+		await waitFor(() => captured.isSuccess);
+
+		expect(captured.data).toEqual({ id: "1", name: "canonical" });
+		const [requestUrl, requestInit] = fetchMock.mock.calls[0] ?? [];
+		const init = requestInit as RequestInit | undefined;
+		expect(String(requestUrl)).toContain(
+			"http://test.local/api/canonical/items",
+		);
+		expect(new Headers(init?.headers).get("x-canonical")).toBe("bound");
+		expect(init?.credentials).toBe("include");
 	});
 
 	it("use() respects the enabled option", async () => {

--- a/packages/stack/src/api/index.ts
+++ b/packages/stack/src/api/index.ts
@@ -27,6 +27,7 @@ import {
 	type ComposedEndpointInventoryEntry,
 } from "../plugins/api/endpoint-inventory";
 import { serializeValidationIssues } from "../plugins/api/create-endpoint";
+import { resolvePluginRegistrationIds } from "../plugin-registration";
 
 export { toNodeHandler } from "better-call/node";
 
@@ -97,6 +98,7 @@ export function createBackendStack<
 	},
 ): BackendStack<TRoutes, PluginApis<TPlugins>, PluginOperations<TPlugins>> {
 	const { plugins, adapter, dbSchema, basePath } = config;
+	const registrationIds = resolvePluginRegistrationIds(plugins, "backend");
 	const runtimeAuth = (
 		config as unknown as { auth?: ServerAuth<AnyAuthorization> }
 	).auth;
@@ -188,7 +190,7 @@ export function createBackendStack<
 		endpointInventory.push(
 			...composeEndpointInventory(
 				pluginKey,
-				plugin.name,
+				plugin.name ?? registrationIds[pluginKey]!,
 				pluginRoutes,
 				pluginOperations[pluginKey] ?? {},
 				plugin.operations !== undefined || runtimeAuth !== undefined,

--- a/packages/stack/src/api/index.ts
+++ b/packages/stack/src/api/index.ts
@@ -27,7 +27,10 @@ import {
 	type ComposedEndpointInventoryEntry,
 } from "../plugins/api/endpoint-inventory";
 import { serializeValidationIssues } from "../plugins/api/create-endpoint";
-import { resolvePluginRegistrationIds } from "../plugin-registration";
+import {
+	resolvePluginProgrammaticId,
+	resolvePluginRegistrationIds,
+} from "../plugin-registration";
 
 export { toNodeHandler } from "better-call/node";
 
@@ -109,7 +112,7 @@ export function createBackendStack<
 	}
 
 	// Collect all routes from all plugins with type-safe prefixed keys
-	const allRoutes = {} as TRoutes;
+	const allRoutes = Object.create(null) as TRoutes;
 
 	let betterDbSchema = dbSchema ?? defineDb({});
 
@@ -123,10 +126,14 @@ export function createBackendStack<
 
 	// Keep the constructed route maps on the shared context so introspection
 	// plugins inspect the real routes instead of invoking factories a second time.
-	const pluginRoutesByName: Record<string, Record<string, any>> = {};
+	const pluginRoutesByName: Record<string, Record<string, any>> = Object.create(
+		null,
+	);
 
 	// Create context for plugins that need access to all plugins (e.g., openAPI)
-	const pluginOperations: Record<string, Record<string, any>> = {};
+	const pluginOperations: Record<string, Record<string, any>> = Object.create(
+		null,
+	);
 	const endpointInventory: ComposedEndpointInventoryEntry[] = [];
 	const context: StackContext = {
 		plugins,
@@ -145,9 +152,9 @@ export function createBackendStack<
 	const routeOperationApis: Record<
 		string,
 		Record<string, RouteOperation<AnyOperation>>
-	> = {};
+	> = Object.create(null);
 	for (const [pluginKey, operations] of Object.entries(pluginOperations)) {
-		routeOperationApis[pluginKey] = {};
+		routeOperationApis[pluginKey] = Object.create(null);
 		for (const [operationKey, operation] of Object.entries(operations)) {
 			const invoke = (input: unknown, request: Request) =>
 				runAuthorizedOperation(operation, input, {
@@ -184,15 +191,15 @@ export function createBackendStack<
 		const pluginRoutes = plugin.routes(
 			adapterInstance,
 			context,
-			routeOperationApis[pluginKey] ?? {},
+			routeOperationApis[pluginKey] ?? Object.create(null),
 		);
 		pluginRoutesByName[pluginKey] = pluginRoutes;
 		endpointInventory.push(
 			...composeEndpointInventory(
 				pluginKey,
-				plugin.name ?? registrationIds[pluginKey]!,
+				resolvePluginProgrammaticId(plugin, registrationIds[pluginKey]!),
 				pluginRoutes,
-				pluginOperations[pluginKey] ?? {},
+				pluginOperations[pluginKey] ?? Object.create(null),
 				plugin.operations !== undefined || runtimeAuth !== undefined,
 				plugin.infrastructureRoutes,
 				plugin.operationRouteMap,
@@ -211,7 +218,7 @@ export function createBackendStack<
 	});
 
 	// Build the typed api surface by calling each plugin's api factory
-	const pluginApis = {} as PluginApis<TPlugins>;
+	const pluginApis = Object.create(null) as PluginApis<TPlugins>;
 	for (const [pluginKey, plugin] of Object.entries(plugins)) {
 		if (plugin.api) {
 			(pluginApis as any)[pluginKey] = plugin.api(adapterInstance);
@@ -230,9 +237,9 @@ export function createBackendStack<
 		const result: Record<
 			string,
 			Record<string, (input: unknown) => unknown>
-		> = {};
+		> = Object.create(null);
 		for (const [pluginKey, operations] of Object.entries(pluginOperations)) {
-			result[pluginKey] = {};
+			result[pluginKey] = Object.create(null);
 			for (const [operationKey, operation] of Object.entries(operations)) {
 				result[pluginKey]![operationKey] = (input: unknown) =>
 					runAuthorizedOperation(operation, input, {
@@ -247,9 +254,9 @@ export function createBackendStack<
 	const internalResult: Record<
 		string,
 		Record<string, (input: unknown) => unknown>
-	> = {};
+	> = Object.create(null);
 	for (const [pluginKey, operations] of Object.entries(pluginOperations)) {
-		internalResult[pluginKey] = {};
+		internalResult[pluginKey] = Object.create(null);
 		for (const [operationKey, operation] of Object.entries(operations)) {
 			internalResult[pluginKey]![operationKey] = (input: unknown) =>
 				runInternalOperation(operation, input);

--- a/packages/stack/src/client/index.ts
+++ b/packages/stack/src/client/index.ts
@@ -14,6 +14,7 @@ import type {
 	Sitemap,
 } from "../types";
 import { resolveClientRuntime } from "./runtime";
+import { resolvePluginRegistrationIds } from "../plugin-registration";
 export type {
 	ClientApiConfig,
 	ClientApiEndpointOverride,
@@ -34,7 +35,7 @@ export type {
 	ResolvedClientStackConfig,
 } from "../types";
 
-type AnyPluginMap = Record<string, ClientPluginRegistration<any, any>>;
+type AnyPluginMap = Record<string, ClientPluginRegistration<any, any, any>>;
 type LegacyPluginMap = Record<string, ClientPlugin<any, any>>;
 
 function hasResolvedRuntime<TPlugins extends AnyPluginMap>(
@@ -46,14 +47,6 @@ function hasResolvedRuntime<TPlugins extends AnyPluginMap>(
 		Object.hasOwn(config, "queryClient") ||
 		Object.hasOwn(config, "endpoints")
 	);
-}
-
-function isPlainPluginMap(value: unknown): value is AnyPluginMap {
-	if (value === null || typeof value !== "object" || Array.isArray(value)) {
-		return false;
-	}
-	const prototype = Object.getPrototypeOf(value);
-	return prototype === Object.prototype || prototype === null;
 }
 
 /**
@@ -106,14 +99,12 @@ export function createClientStack<
 >(
 	config: ClientStackConfig<TPlugins>,
 ): ClientStack<TRoutes> | ResolvedClientStack<TRoutes, TPlugins> {
-	const registrations = Object.hasOwn(config, "plugins")
-		? config.plugins
-		: undefined;
-	if (!isPlainPluginMap(registrations)) {
-		throw new Error(`[btst/client] plugins must be a plugin registration map.`);
-	}
+	const registrations = config.plugins;
+	const registrationIds = resolvePluginRegistrationIds(registrations, "client");
 	const canonical = hasResolvedRuntime(config);
-	const runtime = canonical ? resolveClientRuntime(config) : undefined;
+	const runtime = canonical
+		? resolveClientRuntime(config, registrationIds)
+		: undefined;
 	const resolvedPlugins: Record<string, ClientPlugin<any, any>> = Object.create(
 		null,
 	);
@@ -133,8 +124,11 @@ export function createClientStack<
 				);
 			}
 			resolvedPlugins[pluginKey] = {
-				name: definition.name,
 				...resolution,
+				...(Object.hasOwn(definition, "id")
+					? { id: registrationIds[pluginKey] }
+					: {}),
+				name: definition.name ?? registrationIds[pluginKey],
 			};
 		} else {
 			resolvedPlugins[pluginKey] = registration as ClientPlugin<any, any>;

--- a/packages/stack/src/client/index.ts
+++ b/packages/stack/src/client/index.ts
@@ -14,7 +14,10 @@ import type {
 	Sitemap,
 } from "../types";
 import { resolveClientRuntime } from "./runtime";
-import { resolvePluginRegistrationIds } from "../plugin-registration";
+import {
+	resolvePluginProgrammaticId,
+	resolvePluginRegistrationIds,
+} from "../plugin-registration";
 export type {
 	ClientApiConfig,
 	ClientApiEndpointOverride,
@@ -99,8 +102,11 @@ export function createClientStack<
 >(
 	config: ClientStackConfig<TPlugins>,
 ): ClientStack<TRoutes> | ResolvedClientStack<TRoutes, TPlugins> {
-	const registrations = config.plugins;
+	const registrations = Object.hasOwn(config, "plugins")
+		? config.plugins
+		: undefined;
 	const registrationIds = resolvePluginRegistrationIds(registrations, "client");
+	const validatedRegistrations = registrations as TPlugins;
 	const canonical = hasResolvedRuntime(config);
 	const runtime = canonical
 		? resolveClientRuntime(config, registrationIds)
@@ -109,7 +115,9 @@ export function createClientStack<
 		null,
 	);
 
-	for (const [pluginKey, registration] of Object.entries(registrations)) {
+	for (const [pluginKey, registration] of Object.entries(
+		validatedRegistrations,
+	)) {
 		if (Object.hasOwn(registration, "resolve")) {
 			if (!runtime) {
 				throw new Error(
@@ -128,7 +136,16 @@ export function createClientStack<
 				...(Object.hasOwn(definition, "id")
 					? { id: registrationIds[pluginKey] }
 					: {}),
-				name: definition.name ?? registrationIds[pluginKey],
+				name: resolvePluginProgrammaticId(
+					definition,
+					registrationIds[pluginKey]!,
+				),
+			};
+		} else if (Object.hasOwn(registration, "id")) {
+			resolvedPlugins[pluginKey] = {
+				...(registration as ClientPlugin<any, any>),
+				id: registrationIds[pluginKey],
+				name: registrationIds[pluginKey],
 			};
 		} else {
 			resolvedPlugins[pluginKey] = registration as ClientPlugin<any, any>;

--- a/packages/stack/src/client/runtime.ts
+++ b/packages/stack/src/client/runtime.ts
@@ -9,7 +9,7 @@ import type {
 	ResolvedClientStackConfig,
 } from "../types";
 
-type AnyPluginMap = Record<string, ClientPluginRegistration<any, any>>;
+type AnyPluginMap = Record<string, ClientPluginRegistration<any, any, any>>;
 
 interface ResolvedClientRuntime<TPlugins extends AnyPluginMap> {
 	pluginRuntimes: { [K in keyof TPlugins]: ResolvedClientPluginRuntime };
@@ -200,6 +200,7 @@ function projectApi(
 /** Resolves one request/browser runtime and its request-data-free provider view. */
 export function resolveClientRuntime<TPlugins extends AnyPluginMap>(
 	config: ResolvedClientStackConfig<TPlugins>,
+	registrationIds: Readonly<Record<string, string>>,
 ): ResolvedClientRuntime<TPlugins> {
 	const apiConfig = ownValue(config, "api");
 	const siteConfig = ownValue(config, "site");
@@ -253,6 +254,7 @@ export function resolveClientRuntime<TPlugins extends AnyPluginMap>(
 		Object.create(null);
 
 	for (const pluginKey of Object.keys(plugins)) {
+		const id = registrationIds[pluginKey]!;
 		const endpoint =
 			endpoints && Object.hasOwn(endpoints, pluginKey)
 				? endpoints[pluginKey]
@@ -298,6 +300,7 @@ export function resolveClientRuntime<TPlugins extends AnyPluginMap>(
 		);
 
 		pluginRuntimes[pluginKey] = nullRecord({
+			id,
 			api: nullRecord({
 				...pluginApi,
 				...(headers ? { headers } : {}),
@@ -307,6 +310,7 @@ export function resolveClientRuntime<TPlugins extends AnyPluginMap>(
 			queryClient,
 		});
 		providerPlugins[pluginKey] = nullRecord({
+			id,
 			api: projectApi(pluginApi, browserHeaders, credentials),
 			site: pluginSite,
 		});
@@ -320,9 +324,7 @@ export function resolveClientRuntime<TPlugins extends AnyPluginMap>(
 			api,
 			site,
 			queryClient,
-			plugins: providerPlugins as {
-				[K in keyof TPlugins]: ClientProviderPluginRuntime;
-			},
+			plugins: providerPlugins as ClientProviderProjection<TPlugins>["plugins"],
 		}),
 	});
 }

--- a/packages/stack/src/context/provider.tsx
+++ b/packages/stack/src/context/provider.tsx
@@ -1,5 +1,16 @@
 "use client";
-import { createContext, useContext, type ReactNode } from "react";
+import {
+	createContext,
+	useContext,
+	type ReactElement,
+	type ReactNode,
+} from "react";
+import type {
+	ClientProviderPluginRuntime,
+	InferredPluginOverrides,
+	RegisteredClientPlugins,
+	ResolvedClientStack,
+} from "../types";
 import type { StackClientAuth, StackIdentity } from "../shared/auth-types";
 import type { StackI18nProvider } from "../shared/i18n-types";
 import type { StackNotifyProvider } from "../shared/notify-types";
@@ -30,6 +41,8 @@ interface StackContextValue<TPluginOverrides extends Record<string, any>> {
 	 * Top-level API config applied to all plugins.
 	 */
 	api?: StackApiConfig;
+	/** Effective browser-safe runtime for each registered client plugin. */
+	plugins?: Record<string, ClientProviderPluginRuntime>;
 	/** Top-level auth provider used by identity-aware components. */
 	auth?: StackClientAuth;
 }
@@ -44,6 +57,46 @@ const StackContext = createContext<StackContextValue<any> | null>(null);
 export type StackProviderOverrides<
 	TPluginOverrides extends Record<string, any>,
 > = Partial<TPluginOverrides>;
+
+type StackProviderServices = {
+	children?: ReactNode;
+	router?: StackRouterConfig;
+	/**
+	 * Browser authorization created by `createClientAuth()`. When omitted,
+	 * identity is `null` and presentation-only descriptor checks remain
+	 * permissive; backend authorization is independent and authoritative.
+	 */
+	auth?: StackClientAuth;
+	/**
+	 * Request identity resolved on the server. `undefined` means no snapshot was
+	 * supplied; `null` is an explicitly hydrated anonymous identity.
+	 */
+	initialIdentity?: StackIdentity | null;
+	notify?: StackNotifyProvider;
+	i18n?: StackI18nProvider;
+};
+
+type CanonicalStackProviderProps<TStack extends ResolvedClientStack<any, any>> =
+	StackProviderServices & {
+		/** Resolved browser client stack; supplies API/site/plugin runtime once. */
+		stack: TStack;
+		overrides?: InferredPluginOverrides<
+			NoInfer<RegisteredClientPlugins<TStack>>
+		>;
+		/** Runtime paths come from `stack`. */
+		basePath?: never;
+		/** Runtime API configuration comes from `stack`. */
+		api?: never;
+	};
+
+type LegacyStackProviderProps<TPluginOverrides extends Record<string, any>> =
+	StackProviderServices & {
+		/** @deprecated Pass the resolved `stack` instead. Removed by #225. */
+		stack?: never;
+		overrides?: StackProviderOverrides<TPluginOverrides>;
+		basePath: string;
+		api?: StackApiConfig;
+	};
 
 /** Removes keys whose value is `undefined` so they don't clobber lower layers in spreads. */
 function stripUndefined<T extends Record<string, any>>(obj: T): Partial<T> {
@@ -97,18 +150,20 @@ function RouterBridge({
  * Provider component for BTST context
  * Provides type-safe access to plugin-specific overrides
  *
- * Only requires override values, not plugin objects - keeps bundle size minimal!
- *
  * @example
  * ```tsx
- * // Define the type shape (no import of plugin values needed!)
- * type MyPluginOverrides = {
- *   messages: MessagesPluginOverrides;
- * };
+ * const clientStack = createClientStack({
+ *   api,
+ *   site,
+ *   queryClient,
+ *   plugins: {
+ *     messages: messagesClientPlugin(),
+ *   },
+ * });
  *
- * <StackProvider<MyPluginOverrides>
+ * <StackProvider
+ *   stack={clientStack}
  *   router={frameworkRouter}
- *   api={{ baseURL, basePath: "/api/data" }}
  *   overrides={{
  *     messages: {
  *       MarkdownRenderer: (props) => <ReactMarkdown {...props} />,
@@ -119,20 +174,18 @@ function RouterBridge({
  * </StackProvider>
  * ```
  *
- * Framework router and API wiring live at the top level. Per-plugin overrides
- * carry only genuinely plugin-specific values:
+ * Runtime locations and plugin override types come from the resolved stack.
+ * Framework services and optional identity hydration remain provider concerns.
  *
  * @example
  * ```tsx
  * import { nextRouter } from "@btst/stack/next";
  *
- * <StackProvider<MyPluginOverrides>
- *   basePath="/pages"
+ * <StackProvider
+ *   stack={clientStack}
  *   router={nextRouter()}
- *   api={{ baseURL, basePath: "/api/data" }}
- *   overrides={{
- *     blog: { uploadImage },
- *   }}
+ *   auth={clientAuth}
+ *   initialIdentity={initialIdentity}
  * >
  *   {children}
  * </StackProvider>
@@ -140,49 +193,37 @@ function RouterBridge({
  */
 export function StackProvider<
 	TPluginOverrides extends Record<string, any> = Record<string, any>,
->({
+>(props: LegacyStackProviderProps<TPluginOverrides>): ReactElement;
+export function StackProvider<
+	const TStack extends ResolvedClientStack<any, any>,
+>(props: CanonicalStackProviderProps<TStack>): ReactElement;
+export function StackProvider({
 	children,
 	overrides,
 	basePath,
+	stack,
 	router,
 	api,
 	auth,
 	initialIdentity,
 	notify,
 	i18n,
-}: {
-	children?: ReactNode;
-	overrides?: StackProviderOverrides<TPluginOverrides>;
-	basePath: string;
-	router?: StackRouterConfig;
-	api?: StackApiConfig;
-	/**
-	 * Browser authorization created by `createClientAuth()`. When omitted,
-	 * identity is `null` and presentation-only descriptor checks remain
-	 * permissive; backend authorization is independent and authoritative.
-	 */
-	auth?: StackClientAuth;
-	/**
-	 * Request identity resolved on the server. `undefined` means no snapshot was
-	 * supplied; `null` is an explicitly hydrated anonymous identity.
-	 */
-	initialIdentity?: StackIdentity | null;
-	/**
-	 * Optional notification provider. When omitted, sonner toasts are used via
-	 * `useNotify()`.
-	 */
-	notify?: StackNotifyProvider;
-	/**
-	 * Optional i18n provider. When omitted, `useTranslate()` returns English
-	 * defaults with `{{param}}` interpolation.
-	 */
-	i18n?: StackI18nProvider;
-}) {
+}:
+	| LegacyStackProviderProps<Record<string, any>>
+	| CanonicalStackProviderProps<ResolvedClientStack<any, any>>): ReactElement {
+	const projection = stack?.provider;
+	const resolvedBasePath = projection?.site.basePath ?? basePath;
+	if (resolvedBasePath === undefined) {
+		throw new Error(
+			"StackProvider requires a resolved client stack or a legacy basePath.",
+		);
+	}
 	const staticRouter = resolveStaticRouter(router);
 	const value: Omit<StackContextValue<any>, "router"> = {
 		overrides: overrides ?? {},
-		basePath,
-		api,
+		basePath: resolvedBasePath,
+		api: projection?.api ?? api,
+		plugins: projection?.plugins,
 		auth,
 	};
 

--- a/packages/stack/src/plugin-registration.ts
+++ b/packages/stack/src/plugin-registration.ts
@@ -1,0 +1,72 @@
+type PluginSide = "client" | "backend";
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return false;
+	}
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function isPluginObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Validates canonical plugin IDs before any plugin factory or adapter work.
+ * Legacy plugins without an own `id` remain bound to their registration key.
+ */
+export function resolvePluginRegistrationIds(
+	plugins: unknown,
+	side: PluginSide,
+): Record<string, string> {
+	if (!isPlainRecord(plugins)) {
+		throw new Error(
+			`[btst/${side}] plugins must be a plugin registration map.`,
+		);
+	}
+
+	const idsByKey: Record<string, string> = Object.create(null);
+	const firstKeyById = new Map<string, string>();
+	const canonical: Array<{ key: string; id: string }> = [];
+
+	for (const [key, plugin] of Object.entries(plugins)) {
+		if (!isPluginObject(plugin)) {
+			throw new Error(
+				`[btst/${side}] ${side === "client" ? "Client" : "Backend"} plugin registration "${key}" must be a plugin object.`,
+			);
+		}
+
+		if (!Object.hasOwn(plugin, "id")) {
+			idsByKey[key] = key;
+			continue;
+		}
+
+		const id = plugin.id;
+		if (typeof id !== "string" || id.length === 0) {
+			throw new Error(
+				`[btst/${side}] ${side === "client" ? "Client" : "Backend"} plugin registered as "${key}" has an invalid ID. IDs must be non-empty strings.`,
+			);
+		}
+
+		const firstKey = firstKeyById.get(id);
+		if (firstKey !== undefined) {
+			throw new Error(
+				`[btst/${side}] ${side === "client" ? "Client" : "Backend"} plugin ID "${id}" is duplicated by conflicting registration keys "${firstKey}" and "${key}". Multiple-instance aliases are not supported.`,
+			);
+		}
+		firstKeyById.set(id, key);
+		idsByKey[key] = id;
+		canonical.push({ key, id });
+	}
+
+	for (const { key, id } of canonical) {
+		if (key !== id) {
+			throw new Error(
+				`[btst/${side}] ${side === "client" ? "Client" : "Backend"} plugin registration key "${key}" conflicts with declared ID "${id}". Registration keys must match plugin IDs; aliases are not supported.`,
+			);
+		}
+	}
+
+	return idsByKey;
+}

--- a/packages/stack/src/plugin-registration.ts
+++ b/packages/stack/src/plugin-registration.ts
@@ -12,6 +12,18 @@ function isPluginObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/** Resolve the stable programmatic ID while retaining legacy `name` support. */
+export function resolvePluginProgrammaticId(
+	plugin: object,
+	registrationId: string,
+): string {
+	if (Object.hasOwn(plugin, "id")) return registrationId;
+	const legacyName = (plugin as { name?: unknown }).name;
+	return typeof legacyName === "string" && legacyName.length > 0
+		? legacyName
+		: registrationId;
+}
+
 /**
  * Validates canonical plugin IDs before any plugin factory or adapter work.
  * Legacy plugins without an own `id` remain bound to their registration key.

--- a/packages/stack/src/plugins/api/index.ts
+++ b/packages/stack/src/plugins/api/index.ts
@@ -13,6 +13,22 @@
 import type { BackendPlugin } from "../../types";
 import type { Endpoint } from "better-call";
 
+type IdentifiedBackendPlugin<
+	TId extends string,
+	TRoutes extends Record<string, Endpoint>,
+	TApi extends Record<string, (...args: any[]) => any>,
+	TOperations extends import("./operation").OperationRecord,
+> = BackendPlugin<TRoutes, TApi, TOperations, TId> & { readonly id: TId };
+
+type LegacyBackendPlugin<
+	TRoutes extends Record<string, Endpoint>,
+	TApi extends Record<string, (...args: any[]) => any>,
+	TOperations extends import("./operation").OperationRecord,
+> = BackendPlugin<TRoutes, TApi, TOperations> & {
+	name: string;
+	readonly id?: never;
+};
+
 export type {
 	BackendPlugin,
 	ClientPlugin,
@@ -61,7 +77,7 @@ export {
  * @example
  * ```ts
  * const messagesPlugin = defineBackendPlugin({
- *   name: "messages",
+ *   id: "messages",
  *   dbPlugin: createDbPlugin("messages", messagesSchema),
  *   routes: (adapter) => ({
  *     list: endpoint("/messages", { method: "GET" }, async () => { ... }),
@@ -75,11 +91,22 @@ export {
  * @template TApi - The shape of the server-side api surface (auto-inferred from api factory)
  */
 export function defineBackendPlugin<
+	const TId extends string,
 	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
 	TApi extends Record<string, (...args: any[]) => any> = never,
 	TOperations extends import("./operation").OperationRecord = never,
 >(
-	plugin: BackendPlugin<TRoutes, TApi, TOperations>,
-): BackendPlugin<TRoutes, TApi, TOperations> {
+	plugin: IdentifiedBackendPlugin<TId, TRoutes, TApi, TOperations>,
+): IdentifiedBackendPlugin<TId, TRoutes, TApi, TOperations>;
+export function defineBackendPlugin<
+	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
+	TApi extends Record<string, (...args: any[]) => any> = never,
+	TOperations extends import("./operation").OperationRecord = never,
+>(
+	plugin: LegacyBackendPlugin<TRoutes, TApi, TOperations>,
+): LegacyBackendPlugin<TRoutes, TApi, TOperations>;
+export function defineBackendPlugin(
+	plugin: BackendPlugin<any, any, any>,
+): BackendPlugin<any, any, any> {
 	return plugin;
 }

--- a/packages/stack/src/plugins/api/index.ts
+++ b/packages/stack/src/plugins/api/index.ts
@@ -105,6 +105,13 @@ export function defineBackendPlugin<
 >(
 	plugin: LegacyBackendPlugin<TRoutes, TApi, TOperations>,
 ): LegacyBackendPlugin<TRoutes, TApi, TOperations>;
+export function defineBackendPlugin<
+	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
+	TApi extends Record<string, (...args: any[]) => any> = never,
+	TOperations extends import("./operation").OperationRecord = never,
+>(
+	plugin: BackendPlugin<TRoutes, TApi, TOperations>,
+): BackendPlugin<TRoutes, TApi, TOperations>;
 export function defineBackendPlugin(
 	plugin: BackendPlugin<any, any, any>,
 ): BackendPlugin<any, any, any> {

--- a/packages/stack/src/plugins/client/index.ts
+++ b/packages/stack/src/plugins/client/index.ts
@@ -13,6 +13,43 @@
 import type { ClientPlugin, ClientPluginDefinition } from "../../types";
 import type { Route } from "@btst/yar";
 
+type IdentifiedClientPlugin<
+	TId extends string,
+	TOverrides,
+	TRoutes extends Record<string, Route>,
+> = ClientPlugin<TOverrides, TRoutes, TId> & { readonly id: TId };
+
+type IdentifiedClientPluginDefinition<
+	TId extends string,
+	TOverrides,
+	TRoutes extends Record<string, Route>,
+> = ClientPluginDefinition<TOverrides, TRoutes, TId> & { readonly id: TId };
+
+type LegacyClientPlugin<
+	TOverrides,
+	TRoutes extends Record<string, Route>,
+> = ClientPlugin<TOverrides, TRoutes> & {
+	name: string;
+	readonly id?: never;
+};
+
+type LegacyClientPluginDefinition<
+	TOverrides,
+	TRoutes extends Record<string, Route>,
+> = ClientPluginDefinition<TOverrides, TRoutes> & {
+	name: string;
+	readonly id?: never;
+};
+
+interface DefineClientPluginWithOverrides<TOverrides> {
+	<const TId extends string, TRoutes extends Record<string, Route>>(
+		plugin: IdentifiedClientPlugin<TId, TOverrides, TRoutes>,
+	): IdentifiedClientPlugin<TId, TOverrides, TRoutes>;
+	<const TId extends string, TRoutes extends Record<string, Route>>(
+		plugin: IdentifiedClientPluginDefinition<TId, TOverrides, TRoutes>,
+	): IdentifiedClientPluginDefinition<TId, TOverrides, TRoutes>;
+}
+
 export type {
 	ClientPlugin,
 	ClientPluginDefinition,
@@ -77,11 +114,15 @@ export { createClient } from "better-call/client";
  * @example
  * ```ts
  * const messagesPlugin = defineClientPlugin({
- *   name: "messages",
- *   routes: () => ({
- *     messagesList: createRoute("/messages", () => ({ ... }))
+ *   id: "messages",
+ *   resolve: (runtime) => ({
+ *     routes: () => ({
+ *       messagesList: createRoute("/messages", () => ({ ... }))
+ *     }),
+ *     sitemap: () => [{
+ *       url: `${runtime.site.baseURL}${runtime.site.basePath}/messages`,
+ *     }],
  *   }),
- *   sitemap: () => [{ url: "/messages", lastModified: new Date(), priority: 0.8 }]
  * });
  * ```
  *
@@ -89,24 +130,41 @@ export { createClient } from "better-call/client";
  * @template TRoutes - The exact shape of routes this plugin provides (preserves keys and route types)
  */
 export function defineClientPlugin<
-	TOverrides = Record<string, never>,
-	TRoutes extends Record<string, Route> = Record<string, Route>,
->(plugin: ClientPlugin<TOverrides, TRoutes>): ClientPlugin<TOverrides, TRoutes>;
+	TOverrides,
+>(): DefineClientPluginWithOverrides<TOverrides>;
 export function defineClientPlugin<
-	TOverrides = Record<string, never>,
+	const TId extends string,
+	TRoutes extends Record<string, Route>,
+>(
+	plugin: IdentifiedClientPlugin<TId, Record<string, never>, TRoutes>,
+): IdentifiedClientPlugin<TId, Record<string, never>, TRoutes>;
+export function defineClientPlugin<
+	const TId extends string,
+	TRoutes extends Record<string, Route>,
+>(
+	plugin: IdentifiedClientPluginDefinition<TId, Record<string, never>, TRoutes>,
+): IdentifiedClientPluginDefinition<TId, Record<string, never>, TRoutes>;
+export function defineClientPlugin<
+	TOverrides,
 	TRoutes extends Record<string, Route> = Record<string, Route>,
 >(
-	plugin: ClientPluginDefinition<TOverrides, TRoutes>,
-): ClientPluginDefinition<TOverrides, TRoutes>;
+	plugin: LegacyClientPlugin<TOverrides, TRoutes>,
+): LegacyClientPlugin<TOverrides, TRoutes>;
 export function defineClientPlugin<
-	TOverrides = Record<string, never>,
+	TOverrides,
 	TRoutes extends Record<string, Route> = Record<string, Route>,
 >(
-	plugin:
-		| ClientPlugin<TOverrides, TRoutes>
-		| ClientPluginDefinition<TOverrides, TRoutes>,
+	plugin: LegacyClientPluginDefinition<TOverrides, TRoutes>,
+): LegacyClientPluginDefinition<TOverrides, TRoutes>;
+export function defineClientPlugin(
+	plugin?: ClientPlugin<any, any> | ClientPluginDefinition<any, any>,
 ):
-	| ClientPlugin<TOverrides, TRoutes>
-	| ClientPluginDefinition<TOverrides, TRoutes> {
+	| ClientPlugin<any, any>
+	| ClientPluginDefinition<any, any>
+	| DefineClientPluginWithOverrides<any> {
+	if (plugin === undefined) {
+		return ((definition: any) =>
+			definition) as DefineClientPluginWithOverrides<any>;
+	}
 	return plugin;
 }

--- a/packages/stack/src/plugins/client/index.ts
+++ b/packages/stack/src/plugins/client/index.ts
@@ -156,6 +156,16 @@ export function defineClientPlugin<
 >(
 	plugin: LegacyClientPluginDefinition<TOverrides, TRoutes>,
 ): LegacyClientPluginDefinition<TOverrides, TRoutes>;
+export function defineClientPlugin<
+	TOverrides = Record<string, never>,
+	TRoutes extends Record<string, Route> = Record<string, Route>,
+>(plugin: ClientPlugin<TOverrides, TRoutes>): ClientPlugin<TOverrides, TRoutes>;
+export function defineClientPlugin<
+	TOverrides = Record<string, never>,
+	TRoutes extends Record<string, Route> = Record<string, Route>,
+>(
+	plugin: ClientPluginDefinition<TOverrides, TRoutes>,
+): ClientPluginDefinition<TOverrides, TRoutes>;
 export function defineClientPlugin(
 	plugin?: ClientPlugin<any, any> | ClientPluginDefinition<any, any>,
 ):

--- a/packages/stack/src/plugins/client/resource/internal.ts
+++ b/packages/stack/src/plugins/client/resource/internal.ts
@@ -28,11 +28,22 @@ export interface ResourceContext {
 
 /** Resolves the plugin overrides and builds the better-call client. */
 export function useResourceContext(plugin: string): ResourceContext {
-	const { api, router } = useStack();
-	const { headers } = usePluginOverrides<ResourceOverrides>(plugin);
+	const { api, plugins, router } = useStack();
+	const { headers: overrideHeaders } =
+		usePluginOverrides<ResourceOverrides>(plugin);
+	const pluginApi = plugins?.[plugin]?.api;
+	const mergedHeaders = new Headers(pluginApi?.browserHeaders);
+	if (overrideHeaders !== undefined) {
+		for (const [name, value] of new Headers(overrideHeaders)) {
+			mergedHeaders.set(name, value);
+		}
+	}
+	const headers = mergedHeaders.keys().next().done ? undefined : mergedHeaders;
 	const client = createApiClient({
-		baseURL: api?.baseURL,
-		basePath: api?.basePath,
+		baseURL: pluginApi?.baseURL ?? api?.baseURL,
+		basePath: pluginApi?.basePath ?? api?.basePath,
+		headers,
+		credentials: pluginApi?.credentials,
 	});
 	return {
 		client,

--- a/packages/stack/src/plugins/open-api/api/generator.ts
+++ b/packages/stack/src/plugins/open-api/api/generator.ts
@@ -1,5 +1,6 @@
 import type { Endpoint } from "better-call";
 import type { StackContext } from "../../../types";
+import { resolvePluginProgrammaticId } from "../../../plugin-registration";
 import * as z from "zod";
 
 /**
@@ -351,8 +352,9 @@ export function generateOpenAPISchema(
 	for (const [pluginKey, plugin] of Object.entries(context.plugins).sort(
 		([left], [right]) => compareStable(left, right),
 	)) {
+		const pluginId = resolvePluginProgrammaticId(plugin, pluginKey);
 		// Skip the open-api plugin itself
-		if (pluginKey === "openApi" || plugin.name === "open-api") {
+		if (pluginId === "openApi" || pluginId === "open-api") {
 			continue;
 		}
 

--- a/packages/stack/src/plugins/route-docs/client/plugin.tsx
+++ b/packages/stack/src/plugins/route-docs/client/plugin.tsx
@@ -3,6 +3,7 @@ import { defineClientPlugin } from "@btst/stack/plugins/client";
 import { defineRoute } from "@btst/yar";
 import type { QueryClient } from "@tanstack/react-query";
 import type { ClientStackContext } from "../../../types";
+import { resolvePluginProgrammaticId } from "../../../plugin-registration";
 import {
 	generateRouteDocsSchema,
 	fetchAllSitemapEntries,
@@ -65,7 +66,8 @@ export function getRegisteredRoutes(): RegisteredRoute[] {
 	for (const [pluginKey, plugin] of Object.entries(
 		moduleStoredContext.plugins,
 	)) {
-		if (pluginKey === "routeDocs" || plugin.name === "route-docs") continue;
+		const pluginId = resolvePluginProgrammaticId(plugin, pluginKey);
+		if (pluginId === "routeDocs" || pluginId === "route-docs") continue;
 		try {
 			const routes = plugin.routes(moduleStoredContext);
 			for (const [routeKey, route] of Object.entries(routes)) {
@@ -73,7 +75,7 @@ export function getRegisteredRoutes(): RegisteredRoute[] {
 				if (path) {
 					result.push({
 						path,
-						plugin: plugin.name || pluginKey,
+						plugin: pluginId,
 						key: routeKey,
 					});
 				}

--- a/packages/stack/src/plugins/route-docs/generator.ts
+++ b/packages/stack/src/plugins/route-docs/generator.ts
@@ -1,4 +1,5 @@
 import type { ClientStackContext, SitemapEntry } from "../../types";
+import { resolvePluginProgrammaticId } from "../../plugin-registration";
 import type { Route } from "@btst/yar";
 import * as z from "zod";
 
@@ -286,8 +287,9 @@ export async function fetchAllSitemapEntries(
 	const allEntries: PluginSitemapEntry[] = [];
 
 	for (const [pluginKey, plugin] of Object.entries(context.plugins)) {
+		const pluginId = resolvePluginProgrammaticId(plugin, pluginKey);
 		// Skip route-docs plugin
-		if (pluginKey === "routeDocs" || plugin.name === "route-docs") {
+		if (pluginId === "routeDocs" || pluginId === "route-docs") {
 			continue;
 		}
 
@@ -319,7 +321,8 @@ export function generateRouteDocsSchema(
 	const documentedPlugins: DocumentedPlugin[] = [];
 
 	// Group sitemap entries by plugin
-	const sitemapByPlugin: Record<string, PluginSitemapEntry[]> = {};
+	const sitemapByPlugin: Record<string, PluginSitemapEntry[]> =
+		Object.create(null);
 	for (const entry of sitemapEntries) {
 		if (!sitemapByPlugin[entry.pluginKey]) {
 			sitemapByPlugin[entry.pluginKey] = [];
@@ -329,8 +332,9 @@ export function generateRouteDocsSchema(
 
 	// Iterate over all plugins
 	for (const [pluginKey, plugin] of Object.entries(context.plugins)) {
+		const pluginId = resolvePluginProgrammaticId(plugin, pluginKey);
 		// Skip the route-docs plugin itself
-		if (pluginKey === "routeDocs" || plugin.name === "route-docs") {
+		if (pluginId === "routeDocs" || pluginId === "route-docs") {
 			continue;
 		}
 
@@ -372,7 +376,7 @@ export function generateRouteDocsSchema(
 		if (documentedRoutes.length > 0) {
 			documentedPlugins.push({
 				key: pluginKey,
-				name: plugin.name ?? plugin.id ?? pluginKey,
+				name: pluginId,
 				routes: documentedRoutes,
 				sitemapEntries: sitemapByPlugin[pluginKey] || [],
 			});

--- a/packages/stack/src/plugins/route-docs/generator.ts
+++ b/packages/stack/src/plugins/route-docs/generator.ts
@@ -372,7 +372,7 @@ export function generateRouteDocsSchema(
 		if (documentedRoutes.length > 0) {
 			documentedPlugins.push({
 				key: pluginKey,
-				name: plugin.name,
+				name: plugin.name ?? plugin.id ?? pluginKey,
 				routes: documentedRoutes,
 				sitemapEntries: sitemapByPlugin[pluginKey] || [],
 			});

--- a/packages/stack/src/plugins/utils.ts
+++ b/packages/stack/src/plugins/utils.ts
@@ -60,6 +60,8 @@ import type { Router, Endpoint, Status, statusCodes } from "better-call";
 interface CreateApiClientOptions {
 	baseURL?: string;
 	basePath?: string;
+	headers?: HeadersInit;
+	credentials?: RequestCredentials;
 }
 
 /**
@@ -72,7 +74,7 @@ interface CreateApiClientOptions {
 export function createApiClient<
 	TRouter extends Router | Record<string, Endpoint> = Record<string, Endpoint>,
 >(options?: CreateApiClientOptions): ReturnType<typeof createClient<TRouter>> {
-	const { baseURL = "", basePath = "/" } = options ?? {};
+	const { baseURL = "", basePath = "/", headers, credentials } = options ?? {};
 
 	// Normalize baseURL - remove trailing slash if present
 	const normalizedBaseURL = baseURL ? baseURL.replace(/\/$/, "") : "";
@@ -87,5 +89,7 @@ export function createApiClient<
 
 	return createClient<TRouter>({
 		baseURL: apiPath,
+		...(headers !== undefined ? { headers } : {}),
+		...(credentials !== undefined ? { credentials } : {}),
 	});
 }

--- a/packages/stack/src/types.ts
+++ b/packages/stack/src/types.ts
@@ -92,7 +92,9 @@ export interface ResolvedClientApi extends ClientLocation {
 }
 
 /** Shared runtime supplied when a client plugin definition is expanded. */
-export interface ResolvedClientPluginRuntime {
+export interface ResolvedClientPluginRuntime<TId extends string = string> {
+	/** Stable programmatic identifier bound by client-stack registration. */
+	id: TId;
 	/** Effective API endpoint and request-specific transport values. */
 	api: ResolvedClientApi;
 	/** Effective public site location for routes, metadata, and sitemap output. */
@@ -110,7 +112,9 @@ export interface ClientProviderApi extends ClientLocation {
 }
 
 /** Provider-safe endpoint view for one registered plugin. */
-export interface ClientProviderPluginRuntime {
+export interface ClientProviderPluginRuntime<TId extends string = string> {
+	/** Stable programmatic identifier bound by client-stack registration. */
+	id: TId;
 	/** Provider-safe effective API endpoint for this plugin. */
 	api: ClientProviderApi;
 	/** Effective site location for this plugin. */
@@ -169,8 +173,12 @@ export interface BackendPlugin<
 	TRoutes extends Record<string, Endpoint> = Record<string, Endpoint>,
 	TApi extends Record<string, (...args: any[]) => any> = never,
 	TOperations extends OperationRecord = never,
+	TId extends string = string,
 > {
-	name: string;
+	/** Canonical stable programmatic identifier. */
+	readonly id?: TId;
+	/** @deprecated Use `id`. Retained only while first-party plugins migrate. */
+	name?: string;
 
 	/**
 	 * Create API endpoints for this plugin
@@ -229,8 +237,12 @@ export interface BackendPlugin<
 export interface ClientPlugin<
 	TOverrides = Record<string, never>,
 	TRoutes extends Record<string, Route> = Record<string, Route>,
+	TId extends string = string,
 > {
-	name: string;
+	/** Canonical stable programmatic identifier. */
+	readonly id?: TId;
+	/** @deprecated Use `id`. Retained only while first-party plugins migrate. */
+	name?: string;
 
 	/**
 	 * Define routes (pages) for this plugin
@@ -254,22 +266,26 @@ export interface ClientPlugin<
 export interface ClientPluginDefinition<
 	TOverrides = Record<string, never>,
 	TRoutes extends Record<string, Route> = Record<string, Route>,
+	TId extends string = string,
 > {
-	/** Temporary intrinsic plugin name retained during the stable-ID migration. */
-	name: string;
+	/** Canonical stable programmatic identifier. */
+	readonly id?: TId;
+	/** @deprecated Use `id`. Retained only while first-party plugins migrate. */
+	name?: string;
 	/** Expand plugin-specific options against one resolved stack runtime. */
 	resolve: (
-		runtime: ResolvedClientPluginRuntime,
-	) => Omit<ClientPlugin<TOverrides, TRoutes>, "name">;
+		runtime: ResolvedClientPluginRuntime<TId>,
+	) => Omit<ClientPlugin<TOverrides, TRoutes, TId>, "id" | "name">;
 }
 
 /** Canonical definitions plus the temporary already-resolved plugin seam. */
 export type ClientPluginRegistration<
 	TOverrides = Record<string, never>,
 	TRoutes extends Record<string, Route> = Record<string, Route>,
+	TId extends string = string,
 > =
-	| ClientPlugin<TOverrides, TRoutes>
-	| ClientPluginDefinition<TOverrides, TRoutes>;
+	| ClientPlugin<TOverrides, TRoutes, TId>
+	| ClientPluginDefinition<TOverrides, TRoutes, TId>;
 
 /**
  * Utility type that maps each plugin key to the return type of its `api` factory.
@@ -379,7 +395,7 @@ export interface BackendStackConfig<
 > {
 	basePath: string;
 	dbSchema?: DatabaseDefinition;
-	plugins: TPlugins;
+	plugins: TPlugins & MatchingPluginRegistrations<TPlugins>;
 	adapter: (db: DatabaseDefinition) => Adapter;
 	/**
 	 * Server authorization created by `createServerAuth()`. When set,
@@ -403,8 +419,28 @@ export type BackendLibConfig<
 		| undefined,
 > = BackendStackConfig<TPlugins, TAuth>;
 
-type AnyClientPluginRegistration = ClientPluginRegistration<any, any>;
+type AnyClientPluginRegistration = ClientPluginRegistration<any, any, any>;
 type LegacyClientPluginMap = Record<string, ClientPlugin<any, any>>;
+
+/** @internal Extract a required canonical plugin ID, excluding legacy optional IDs. */
+type _DeclaredPluginId<TPlugin> = TPlugin extends {
+	readonly id: infer TId extends string;
+}
+	? TId
+	: never;
+
+/** Reject a registration key that differs from a plugin's declared canonical ID. */
+export type MatchingPluginRegistrations<
+	TPlugins extends Record<string, unknown>,
+> = {
+	[K in keyof TPlugins]: [_DeclaredPluginId<TPlugins[K]>] extends [never]
+		? TPlugins[K]
+		: K extends _DeclaredPluginId<TPlugins[K]>
+			? _DeclaredPluginId<TPlugins[K]> extends K
+				? TPlugins[K]
+				: never
+			: never;
+};
 
 /** Stack-owned endpoint replacements, limited to registered plugin keys. */
 export type ClientPluginEndpointOverrides<
@@ -425,7 +461,7 @@ export interface ResolvedClientStackConfig<
 	/** The one React Query client used by loaders, hydration, and browser hooks. */
 	queryClient: QueryClient;
 	/** Runtime-independent and temporary already-resolved plugin registrations. */
-	plugins: TPlugins;
+	plugins: TPlugins & MatchingPluginRegistrations<TPlugins>;
 	/** Explicit endpoint replacements keyed by a registered plugin name. */
 	endpoints?: ClientPluginEndpointOverrides<TPlugins>;
 	/** Shared origins live under `api` or `site`, never an ambiguous top level. */
@@ -486,12 +522,43 @@ export type ClientLibConfig<
 export type InferPluginOverrides<
 	TPlugins extends Record<string, AnyClientPluginRegistration>,
 > = {
-	[K in keyof TPlugins]: TPlugins[K] extends ClientPluginRegistration<
+	[K in keyof TPlugins]: TPlugins[K] extends ClientPlugin<
 		infer TOverrides,
+		any,
 		any
 	>
 		? TOverrides
-		: never;
+		: TPlugins[K] extends ClientPluginDefinition<infer TOverrides, any, any>
+			? TOverrides
+			: never;
+};
+
+type _HasNoConfigurableOverrides<TOverrides> = [TOverrides] extends [never]
+	? true
+	: [keyof TOverrides] extends [never]
+		? true
+		: TOverrides extends Record<string, never>
+			? true
+			: false;
+
+/**
+ * Provider overrides inferred from registered client definitions. Plugins with
+ * no configurable fields are omitted rather than requiring empty blocks.
+ */
+export type InferredPluginOverrides<
+	TPlugins extends Record<string, AnyClientPluginRegistration>,
+> = keyof _ConfigurablePluginOverrides<TPlugins> extends never
+	? Record<string, never>
+	: _ConfigurablePluginOverrides<TPlugins>;
+
+type _ConfigurablePluginOverrides<
+	TPlugins extends Record<string, AnyClientPluginRegistration>,
+> = {
+	[K in keyof TPlugins as _HasNoConfigurableOverrides<
+		InferPluginOverrides<TPlugins>[K]
+	> extends true
+		? never
+		: K]?: InferPluginOverrides<TPlugins>[K];
 };
 
 /**
@@ -623,6 +690,8 @@ export interface ClientStack<
 	generateSitemap: () => Promise<Sitemap>;
 }
 
+declare const resolvedClientStackPlugins: unique symbol;
+
 /** Browser-safe runtime passed to `StackProvider` by the next composition slice. */
 export interface ClientProviderProjection<
 	TPlugins extends Record<string, AnyClientPluginRegistration> = Record<
@@ -637,7 +706,13 @@ export interface ClientProviderProjection<
 	/** The one React Query client supplied to the client stack. */
 	queryClient: QueryClient;
 	/** Effective provider-safe endpoint values for every registered plugin. */
-	plugins: { [K in keyof TPlugins]: ClientProviderPluginRuntime };
+	plugins: {
+		[K in keyof TPlugins]: ClientProviderPluginRuntime<
+			[_DeclaredPluginId<TPlugins[K]>] extends [never]
+				? K & string
+				: _DeclaredPluginId<TPlugins[K]>
+		>;
+	};
 }
 
 /** Canonical client stack with a browser-safe provider projection. */
@@ -648,9 +723,15 @@ export interface ResolvedClientStack<
 		AnyClientPluginRegistration
 	>,
 > extends ClientStack<TRoutes> {
+	/** @internal Type-only registration map used for provider inference. */
+	readonly [resolvedClientStackPlugins]?: TPlugins;
 	/** Browser-safe projection for provider and browser resource consumers. */
 	provider: ClientProviderProjection<TPlugins>;
 }
+
+/** Registered plugin definitions carried by a resolved client stack type. */
+export type RegisteredClientPlugins<TStack> =
+	TStack extends ResolvedClientStack<any, infer TPlugins> ? TPlugins : never;
 
 /**
  * @deprecated Use `ClientStack`. This alias is removed by #225.


### PR DESCRIPTION
## Summary

- preserve canonical literal client/backend plugin IDs and reject key mismatches or duplicate IDs before composition work
- infer exact provider override keys and values from the resolved client stack while keeping the legacy manual-provider seam
- project registration-bound IDs and endpoint transport into provider/resource consumers without changing authorization or identity behavior
- add public consumer, runtime, provider, resource, and tri-state identity regression coverage

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @btst/stack knip`
- `pnpm test`

Closes #210