### PR TITLE
feat(stack): normalize backend plugin factories

### DIFF
--- a/docs/content/docs/auth.mdx
+++ b/docs/content/docs/auth.mdx
@@ -670,8 +670,10 @@ After:
 const serverAuth = createServerAuth({ authorization, getIdentity: readIdentity });
 
 commentsBackendPlugin({
-  onBeforePost: async (_input, context: CommentsCreateOperationContext) => {
-    await audit(context.identity, context.facts);
+  hooks: {
+    onBeforePost: async (_input, context: CommentsCreateOperationContext) => {
+      await audit(context.identity, context.facts);
+    },
   },
 });
 

--- a/docs/content/docs/plugins/blog.mdx
+++ b/docs/content/docs/plugins/blog.mdx
@@ -426,7 +426,7 @@ const blogHooks: BlogBackendHooks = {
 
 const { handler, dbSchema } = stack({
   plugins: {
-    blog: blogBackendPlugin(blogHooks)
+    blog: blogBackendPlugin({ hooks: blogHooks })
   },
   // ...
 })

--- a/docs/content/docs/plugins/comments.mdx
+++ b/docs/content/docs/plugins/comments.mdx
@@ -365,18 +365,24 @@ approval from marking spam.
 | `allowPosting` | `boolean` | `true` | When `false`, the `POST /comments` endpoint is not registered (read-only comments mode). |
 | `allowEditing` | `boolean` | `true` | When `false`, the `PATCH /comments/:id` edit endpoint is not registered. |
 | `resolveUser` | `(authorId: string) => Promise<{ name: string; avatarUrl?: string } \| null>` | — | Map author IDs to display info; returns `null` → shows `"[deleted]"` |
-| `onBeforeList` | hook | — | Called after authorization and before a list query. |
-| `onBeforeCount` | hook | — | Called after authorization and before a count query. |
-| `onBeforePost` | hook | — | Called after authorization and before a comment is saved. Request identity is authoritative when server authorization is configured. |
-| `onAfterPost` | hook | — | Called after a comment is saved. |
-| `onBeforeEdit` | hook | — | Called after authorization and before a comment body is updated. |
-| `onAfterEdit` | hook | — | Called after a comment body is updated. |
-| `onBeforeLike` | hook | — | Called after authorization and before the request identity's reaction is toggled. |
-| `onBeforeStatusChange` | hook | — | Called after authorization and before moderation status changes. |
-| `onAfterApprove` | hook | — | Called after a comment is approved. |
-| `onBeforeDelete` | hook | — | Called after authorization and before a comment is deleted. |
-| `onAfterDelete` | hook | — | Called after a comment is deleted. |
-| `onBeforeListByAuthor` | hook | — | Called after the own-history rule allows an author-scoped query. |
+| `hooks` | `CommentsBackendHooks` | — | Post-authorization domain lifecycle callbacks. |
+
+Pass lifecycle callbacks inside the `hooks` option:
+
+| `CommentsBackendHooks` field | Description |
+|------------------------------|-------------|
+| `onBeforeList` | Called after authorization and before a list query. |
+| `onBeforeCount` | Called after authorization and before a count query. |
+| `onBeforeListByAuthor` | Called after the own-history rule allows an author-scoped query. |
+| `onBeforePost` | Called after authorization and before a comment is saved. Request identity is authoritative when server authorization is configured. |
+| `onAfterPost` | Called after a comment is saved. |
+| `onBeforeEdit` | Called after authorization and before a comment body is updated. |
+| `onAfterEdit` | Called after a comment body is updated. |
+| `onBeforeLike` | Called after authorization and before the request identity's reaction is toggled. |
+| `onBeforeStatusChange` | Called after authorization and before moderation status changes. |
+| `onAfterApprove` | Called after a comment is approved. |
+| `onBeforeDelete` | Called after authorization and before a comment is deleted. |
+| `onAfterDelete` | Called after a comment is deleted. |
 
 <Callout type="warn">
 All lifecycle hooks receive validated input, server-derived facts, resolved

--- a/docs/content/docs/plugins/comments.mdx
+++ b/docs/content/docs/plugins/comments.mdx
@@ -46,8 +46,10 @@ const { handler, dbSchema } = stack({
           ? { name: user.displayName, avatarUrl: user.avatarUrl }
           : null
       },
-      onAfterApprove: async (comment, ctx) => {
-        await sendApprovalEmail(comment.authorId)
+      hooks: {
+        onAfterApprove: async (comment, ctx) => {
+          await sendApprovalEmail(comment.authorId)
+        },
       },
     })
   },

--- a/docs/content/docs/plugins/development.mdx
+++ b/docs/content/docs/plugins/development.mdx
@@ -179,8 +179,8 @@ import {
 import { z } from "zod"
 import { todoPermissions } from "../permissions"
 
-export const todosBackendPlugin = defineBackendPlugin({
-  name: "todos",
+export const todosBackendPlugin = () => defineBackendPlugin({
+  id: "todos",
   dbPlugin: todosSchema,
 
   operations: (adapter) => ({
@@ -224,7 +224,9 @@ export const todosBackendPlugin = defineBackendPlugin({
   }),
 })
 
-export type TodosApiRouter = ReturnType<typeof todosBackendPlugin.routes>
+export type TodosApiRouter = ReturnType<
+  ReturnType<typeof todosBackendPlugin>["routes"]
+>
 ```
 
 For compound behavior, `additionalPermissions` derives every secondary check
@@ -380,8 +382,8 @@ const operations = (adapter: Adapter) => ({
   }),
 })
 
-export const todosBackendPlugin = defineBackendPlugin({
-  name: "todos",
+export const todosBackendPlugin = () => defineBackendPlugin({
+  id: "todos",
   dbPlugin: dbSchema,
   operations,
   api: (adapter) => ({ prefetchForRoute: createTodoPrefetchForRoute(adapter) }),
@@ -589,8 +591,8 @@ function createTodosPrefetchForRoute(adapter: Adapter): TodosPrefetchForRoute {
   } as TodosPrefetchForRoute
 }
 
-export const todosBackendPlugin = defineBackendPlugin({
-  name: "todos",
+export const todosBackendPlugin = () => defineBackendPlugin({
+  id: "todos",
   dbPlugin: dbSchema,
   api: (adapter) => ({
     listTodos: () => listTodos(adapter),
@@ -868,7 +870,7 @@ This pattern ensures:
 ```ts
 export const myStack = stack({
   basePath: "/api/data",
-  plugins: { todos: todosBackendPlugin, blog: blogBackendPlugin() },
+  plugins: { todos: todosBackendPlugin(), blog: blogBackendPlugin() },
   adapter: (db) => createMemoryAdapter(db)({}),
   auth: serverAuth,
 })

--- a/docs/content/docs/plugins/development.mdx
+++ b/docs/content/docs/plugins/development.mdx
@@ -279,7 +279,7 @@ and a concrete rationale:
 
 ```typescript
 defineBackendPlugin({
-  name: "reference",
+  id: "reference",
   dbPlugin: referenceSchema,
   infrastructureRoutes: {
     schema: {

--- a/docs/content/docs/plugins/kanban.mdx
+++ b/docs/content/docs/plugins/kanban.mdx
@@ -667,7 +667,7 @@ import { kanbanBackendPlugin } from "@btst/stack/plugins/kanban/api"
 const app = stack({
   auth: serverAuth,
   plugins: {
-    kanban: kanbanBackendPlugin(hooks)
+    kanban: kanbanBackendPlugin({ hooks })
   },
   // ...
 })

--- a/packages/stack/consumer-tests/backend-factories/index.cts
+++ b/packages/stack/consumer-tests/backend-factories/index.cts
@@ -1,0 +1,53 @@
+import aiChat = require("@btst/stack/plugins/ai-chat/api");
+import blog = require("@btst/stack/plugins/blog/api");
+import cms = require("@btst/stack/plugins/cms/api");
+import comments = require("@btst/stack/plugins/comments/api");
+import formBuilder = require("@btst/stack/plugins/form-builder/api");
+import kanban = require("@btst/stack/plugins/kanban/api");
+import media = require("@btst/stack/plugins/media/api");
+import openApi = require("@btst/stack/plugins/open-api/api");
+
+const aiOptions = { model: {} as never } satisfies aiChat.AiChatBackendConfig;
+const blogOptions = {} satisfies blog.BlogBackendOptions;
+const cmsOptions = { contentTypes: [] } satisfies cms.CMSBackendConfig;
+const commentsOptions = { hooks: {} } satisfies comments.CommentsBackendOptions;
+const formBuilderOptions = {} satisfies formBuilder.FormBuilderBackendConfig;
+const kanbanOptions = { hooks: {} } satisfies kanban.KanbanBackendOptions;
+const storageAdapter = {} as media.DirectStorageAdapter;
+const mediaOptions = { storageAdapter } satisfies media.MediaBackendConfig;
+const openApiOptions = {} satisfies openApi.OpenAPIOptions;
+
+aiChat.aiChatBackendPlugin(aiOptions).id satisfies "aiChat";
+blog.blogBackendPlugin(blogOptions).id satisfies "blog";
+cms.cmsBackendPlugin(cmsOptions).id satisfies "cms";
+comments.commentsBackendPlugin(commentsOptions).id satisfies "comments";
+formBuilder.formBuilderBackendPlugin(formBuilderOptions)
+	.id satisfies "formBuilder";
+kanban.kanbanBackendPlugin(kanbanOptions).id satisfies "kanban";
+media.mediaBackendPlugin(mediaOptions).id satisfies "media";
+openApi.openApiBackendPlugin(openApiOptions).id satisfies "openApi";
+
+blog.blogBackendPlugin();
+comments.commentsBackendPlugin();
+formBuilder.formBuilderBackendPlugin();
+kanban.kanbanBackendPlugin();
+openApi.openApiBackendPlugin();
+
+// @ts-expect-error AI Chat requires a model.
+aiChat.aiChatBackendPlugin();
+// @ts-expect-error AI Chat requires a model in its options object.
+aiChat.aiChatBackendPlugin({});
+// @ts-expect-error CMS requires content type definitions.
+cms.cmsBackendPlugin();
+// @ts-expect-error CMS requires content type definitions in its options object.
+cms.cmsBackendPlugin({});
+// @ts-expect-error Media requires a storage adapter.
+media.mediaBackendPlugin();
+// @ts-expect-error Media requires a storage adapter in its options object.
+media.mediaBackendPlugin({});
+// @ts-expect-error Blog lifecycle hooks cannot be positional.
+blog.blogBackendPlugin({ onBeforeListPosts: async () => undefined });
+// @ts-expect-error Comments lifecycle hooks cannot be flat options.
+comments.commentsBackendPlugin({ onBeforePost: async () => undefined });
+// @ts-expect-error Kanban lifecycle hooks cannot be positional.
+kanban.kanbanBackendPlugin({ onBeforeListBoards: async () => undefined });

--- a/packages/stack/consumer-tests/backend-factories/index.ts
+++ b/packages/stack/consumer-tests/backend-factories/index.ts
@@ -1,0 +1,77 @@
+import {
+	aiChatBackendPlugin,
+	type AiChatBackendConfig,
+} from "@btst/stack/plugins/ai-chat/api";
+import {
+	blogBackendPlugin,
+	type BlogBackendOptions,
+} from "@btst/stack/plugins/blog/api";
+import {
+	cmsBackendPlugin,
+	type CMSBackendConfig,
+} from "@btst/stack/plugins/cms/api";
+import {
+	commentsBackendPlugin,
+	type CommentsBackendOptions,
+} from "@btst/stack/plugins/comments/api";
+import {
+	formBuilderBackendPlugin,
+	type FormBuilderBackendConfig,
+} from "@btst/stack/plugins/form-builder/api";
+import {
+	kanbanBackendPlugin,
+	type KanbanBackendOptions,
+} from "@btst/stack/plugins/kanban/api";
+import {
+	type DirectStorageAdapter,
+	mediaBackendPlugin,
+	type MediaBackendConfig,
+} from "@btst/stack/plugins/media/api";
+import {
+	openApiBackendPlugin,
+	type OpenAPIOptions,
+} from "@btst/stack/plugins/open-api/api";
+
+const aiOptions = { model: {} as never } satisfies AiChatBackendConfig;
+const blogOptions = {} satisfies BlogBackendOptions;
+const cmsOptions = { contentTypes: [] } satisfies CMSBackendConfig;
+const commentsOptions = { hooks: {} } satisfies CommentsBackendOptions;
+const formBuilderOptions = {} satisfies FormBuilderBackendConfig;
+const kanbanOptions = { hooks: {} } satisfies KanbanBackendOptions;
+const storageAdapter = {} as DirectStorageAdapter;
+const mediaOptions = { storageAdapter } satisfies MediaBackendConfig;
+const openApiOptions = {} satisfies OpenAPIOptions;
+
+aiChatBackendPlugin(aiOptions).id satisfies "aiChat";
+blogBackendPlugin(blogOptions).id satisfies "blog";
+cmsBackendPlugin(cmsOptions).id satisfies "cms";
+commentsBackendPlugin(commentsOptions).id satisfies "comments";
+formBuilderBackendPlugin(formBuilderOptions).id satisfies "formBuilder";
+kanbanBackendPlugin(kanbanOptions).id satisfies "kanban";
+mediaBackendPlugin(mediaOptions).id satisfies "media";
+openApiBackendPlugin(openApiOptions).id satisfies "openApi";
+
+blogBackendPlugin();
+commentsBackendPlugin();
+formBuilderBackendPlugin();
+kanbanBackendPlugin();
+openApiBackendPlugin();
+
+// @ts-expect-error AI Chat requires a model.
+aiChatBackendPlugin();
+// @ts-expect-error AI Chat requires a model in its options object.
+aiChatBackendPlugin({});
+// @ts-expect-error CMS requires content type definitions.
+cmsBackendPlugin();
+// @ts-expect-error CMS requires content type definitions in its options object.
+cmsBackendPlugin({});
+// @ts-expect-error Media requires a storage adapter.
+mediaBackendPlugin();
+// @ts-expect-error Media requires a storage adapter in its options object.
+mediaBackendPlugin({});
+// @ts-expect-error Blog lifecycle hooks cannot be positional.
+blogBackendPlugin({ onBeforeListPosts: async () => undefined });
+// @ts-expect-error Comments lifecycle hooks cannot be flat options.
+commentsBackendPlugin({ onBeforePost: async () => undefined });
+// @ts-expect-error Kanban lifecycle hooks cannot be positional.
+kanbanBackendPlugin({ onBeforeListBoards: async () => undefined });

--- a/packages/stack/consumer-tests/backend-factories/tsconfig.cjs.json
+++ b/packages/stack/consumer-tests/backend-factories/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true
+  },
+  "include": ["./index.cts"]
+}

--- a/packages/stack/consumer-tests/backend-factories/tsconfig.json
+++ b/packages/stack/consumer-tests/backend-factories/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": true
+  },
+  "include": ["./index.ts"]
+}

--- a/packages/stack/src/__tests__/backend-plugin-factories.test.ts
+++ b/packages/stack/src/__tests__/backend-plugin-factories.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { aiChatBackendPlugin } from "../plugins/ai-chat/api";
+import { blogBackendPlugin } from "../plugins/blog/api";
+import { cmsBackendPlugin } from "../plugins/cms/api";
+import { commentsBackendPlugin } from "../plugins/comments/api";
+import { formBuilderBackendPlugin } from "../plugins/form-builder/api";
+import { kanbanBackendPlugin } from "../plugins/kanban/api";
+import {
+	mediaBackendPlugin,
+	type DirectStorageAdapter,
+} from "../plugins/media/api";
+import { openApiBackendPlugin } from "../plugins/open-api/api";
+
+const storageAdapter: DirectStorageAdapter = {
+	type: "local",
+	upload: async (_buffer, { filename }) => ({
+		url: `https://files.example/${filename}`,
+	}),
+	delete: async () => undefined,
+};
+
+describe("first-party backend plugin factories", () => {
+	it("exposes the canonical literal ID for all eight backend plugins", () => {
+		const plugins = [
+			aiChatBackendPlugin({ model: {} as never }),
+			blogBackendPlugin(),
+			cmsBackendPlugin({ contentTypes: [] }),
+			commentsBackendPlugin(),
+			formBuilderBackendPlugin(),
+			kanbanBackendPlugin(),
+			mediaBackendPlugin({ storageAdapter }),
+			openApiBackendPlugin(),
+		];
+
+		expect(plugins.map((plugin) => plugin.id)).toEqual([
+			"aiChat",
+			"blog",
+			"cms",
+			"comments",
+			"formBuilder",
+			"kanban",
+			"media",
+			"openApi",
+		]);
+	});
+
+	it("keeps every optional-only factory callable without an options object", () => {
+		expect(blogBackendPlugin().id).toBe("blog");
+		expect(commentsBackendPlugin().id).toBe("comments");
+		expect(formBuilderBackendPlugin().id).toBe("formBuilder");
+		expect(kanbanBackendPlugin().id).toBe("kanban");
+		expect(openApiBackendPlugin().id).toBe("openApi");
+	});
+});

--- a/packages/stack/src/__tests__/backend-plugin-factories.typecheck.ts
+++ b/packages/stack/src/__tests__/backend-plugin-factories.typecheck.ts
@@ -1,0 +1,133 @@
+import type { DatabaseDefinition, DBAdapter } from "@btst/db";
+import { createBackendStack } from "../api";
+import {
+	createDbPlugin,
+	createEndpoint,
+	defineBackendPlugin,
+} from "../plugins/api";
+import {
+	aiChatBackendPlugin,
+	type AiChatBackendConfig,
+	type AiChatBackendHooks,
+} from "../plugins/ai-chat/api";
+import {
+	blogBackendPlugin,
+	type BlogBackendHooks,
+	type BlogBackendOptions,
+} from "../plugins/blog/api";
+import { cmsBackendPlugin, type CMSBackendConfig } from "../plugins/cms/api";
+import {
+	commentsBackendPlugin,
+	type CommentsBackendHooks,
+	type CommentsBackendOptions,
+} from "../plugins/comments/api";
+import {
+	formBuilderBackendPlugin,
+	type FormBuilderBackendConfig,
+	type FormBuilderBackendHooks,
+} from "../plugins/form-builder/api";
+import {
+	kanbanBackendPlugin,
+	type KanbanBackendHooks,
+	type KanbanBackendOptions,
+} from "../plugins/kanban/api";
+import {
+	type DirectStorageAdapter,
+	mediaBackendPlugin,
+	type MediaBackendConfig,
+	type MediaBackendHooks,
+} from "../plugins/media/api";
+import {
+	openApiBackendPlugin,
+	type OpenAPIOptions,
+} from "../plugins/open-api/api";
+
+const aiHooks = {} satisfies AiChatBackendHooks;
+const blogHooks = {} satisfies BlogBackendHooks;
+const commentsHooks = {} satisfies CommentsBackendHooks;
+const formBuilderHooks = {} satisfies FormBuilderBackendHooks;
+const kanbanHooks = {} satisfies KanbanBackendHooks;
+const mediaHooks = {} satisfies MediaBackendHooks;
+const storageAdapter = {} as DirectStorageAdapter;
+
+const aiOptions = {
+	model: {} as never,
+	hooks: aiHooks,
+} satisfies AiChatBackendConfig;
+const blogOptions = { hooks: blogHooks } satisfies BlogBackendOptions;
+const cmsOptions = { contentTypes: [], hooks: {} } satisfies CMSBackendConfig;
+const commentsOptions = {
+	allowEditing: true,
+	resolveUser: async () => null,
+	hooks: commentsHooks,
+} satisfies CommentsBackendOptions;
+const formBuilderOptions = {
+	hooks: formBuilderHooks,
+} satisfies FormBuilderBackendConfig;
+const kanbanOptions = { hooks: kanbanHooks } satisfies KanbanBackendOptions;
+const mediaOptions = {
+	storageAdapter,
+	resolveTenantId: async () => undefined,
+	hooks: mediaHooks,
+} satisfies MediaBackendConfig;
+const openApiOptions = {
+	title: "Example",
+	version: "1.0.0",
+} satisfies OpenAPIOptions;
+
+aiChatBackendPlugin(aiOptions).id satisfies "aiChat";
+blogBackendPlugin(blogOptions).id satisfies "blog";
+cmsBackendPlugin(cmsOptions).id satisfies "cms";
+commentsBackendPlugin(commentsOptions).id satisfies "comments";
+formBuilderBackendPlugin(formBuilderOptions).id satisfies "formBuilder";
+kanbanBackendPlugin(kanbanOptions).id satisfies "kanban";
+mediaBackendPlugin(mediaOptions).id satisfies "media";
+openApiBackendPlugin(openApiOptions).id satisfies "openApi";
+
+blogBackendPlugin();
+commentsBackendPlugin();
+formBuilderBackendPlugin();
+kanbanBackendPlugin();
+openApiBackendPlugin();
+
+// @ts-expect-error AI Chat requires a model.
+aiChatBackendPlugin();
+// @ts-expect-error AI Chat's required model cannot be defaulted away.
+aiChatBackendPlugin({});
+// @ts-expect-error CMS requires content type definitions.
+cmsBackendPlugin();
+// @ts-expect-error CMS's required content types cannot be defaulted away.
+cmsBackendPlugin({});
+// @ts-expect-error Media requires a server-side storage adapter.
+mediaBackendPlugin();
+// @ts-expect-error Media's required storage adapter cannot be defaulted away.
+mediaBackendPlugin({});
+
+// @ts-expect-error Blog lifecycle callbacks belong under `hooks`.
+blogBackendPlugin({ onBeforeListPosts: async () => undefined });
+// @ts-expect-error Comments lifecycle callbacks belong under `hooks`.
+commentsBackendPlugin({ onBeforePost: async () => undefined });
+// @ts-expect-error Kanban lifecycle callbacks belong under `hooks`.
+kanbanBackendPlugin({ onBeforeListBoards: async () => undefined });
+// @ts-expect-error Form Builder lifecycle callbacks belong under `hooks`.
+formBuilderBackendPlugin({ onBeforeCreateForm: async () => undefined });
+// @ts-expect-error Media lifecycle callbacks belong under `hooks`.
+mediaBackendPlugin({ storageAdapter, onBeforeUpload: async () => undefined });
+
+const consumerBackendPlugin = () =>
+	defineBackendPlugin({
+		id: "consumerProbe",
+		dbPlugin: createDbPlugin("consumer-probe", {}),
+		routes: () => ({
+			probe: createEndpoint("/probe", { method: "GET" }, async () => ({
+				ok: true,
+			})),
+		}),
+	});
+
+consumerBackendPlugin().id satisfies "consumerProbe";
+createBackendStack({
+	basePath: "/api/data",
+	plugins: { consumerProbe: consumerBackendPlugin() },
+	adapter: (_db: DatabaseDefinition) => null as unknown as DBAdapter,
+});

--- a/packages/stack/src/__tests__/package-metadata.test.ts
+++ b/packages/stack/src/__tests__/package-metadata.test.ts
@@ -237,3 +237,90 @@ describe("published symmetric stack constructors", () => {
 		expect(requestApi.__proto__.echo).toBeTypeOf("function");
 	}, 30_000);
 });
+
+describe("published backend plugin factories", () => {
+	it("preserves all eight factory contracts through ESM, CJS and declarations", async () => {
+		const storageAdapter = {
+			type: "local" as const,
+			upload: async (_buffer: Buffer, { filename }: { filename: string }) => ({
+				url: `https://files.example/${filename}`,
+			}),
+			delete: async () => undefined,
+		};
+		const factories = [
+			{
+				specifier: "@btst/stack/plugins/ai-chat/api",
+				exportName: "aiChatBackendPlugin",
+				id: "aiChat",
+				args: [{ model: {} }],
+			},
+			{
+				specifier: "@btst/stack/plugins/blog/api",
+				exportName: "blogBackendPlugin",
+				id: "blog",
+				args: [],
+			},
+			{
+				specifier: "@btst/stack/plugins/cms/api",
+				exportName: "cmsBackendPlugin",
+				id: "cms",
+				args: [{ contentTypes: [] }],
+			},
+			{
+				specifier: "@btst/stack/plugins/comments/api",
+				exportName: "commentsBackendPlugin",
+				id: "comments",
+				args: [],
+			},
+			{
+				specifier: "@btst/stack/plugins/form-builder/api",
+				exportName: "formBuilderBackendPlugin",
+				id: "formBuilder",
+				args: [],
+			},
+			{
+				specifier: "@btst/stack/plugins/kanban/api",
+				exportName: "kanbanBackendPlugin",
+				id: "kanban",
+				args: [],
+			},
+			{
+				specifier: "@btst/stack/plugins/media/api",
+				exportName: "mediaBackendPlugin",
+				id: "media",
+				args: [{ storageAdapter }],
+			},
+			{
+				specifier: "@btst/stack/plugins/open-api/api",
+				exportName: "openApiBackendPlugin",
+				id: "openApi",
+				args: [],
+			},
+		] as const;
+		const require = createRequire(import.meta.url);
+
+		for (const factory of factories) {
+			const esm = (await import(factory.specifier)) as Record<
+				string,
+				(...args: any[]) => { id: string }
+			>;
+			const cjs = require(factory.specifier) as Record<
+				string,
+				(...args: any[]) => { id: string }
+			>;
+			expect(esm[factory.exportName]?.(...factory.args).id).toBe(factory.id);
+			expect(cjs[factory.exportName]?.(...factory.args).id).toBe(factory.id);
+		}
+
+		for (const project of [
+			"consumer-tests/backend-factories/tsconfig.json",
+			"consumer-tests/backend-factories/tsconfig.cjs.json",
+		]) {
+			await execFileAsync(
+				process.execPath,
+				[require.resolve("typescript/lib/tsc.js"), "--project", project],
+				{ cwd: resolve(".") },
+			);
+		}
+	}, 30_000);
+});

--- a/packages/stack/src/plugins/ai-chat/api/plugin.ts
+++ b/packages/stack/src/plugins/ai-chat/api/plugin.ts
@@ -81,7 +81,7 @@ export const aiChatBackendPlugin = <
 	};
 
 	return defineBackendPlugin({
-		name: "ai-chat",
+		id: "aiChat",
 		dbPlugin: dbSchema,
 		operationRouteMap: { chat: "startStream" },
 		operations: (adapter: Adapter) =>

--- a/packages/stack/src/plugins/blog/__tests__/authorization.test.ts
+++ b/packages/stack/src/plugins/blog/__tests__/authorization.test.ts
@@ -123,7 +123,9 @@ function makeBackend(options?: {
 }) {
 	return stack({
 		basePath: "/api",
-		plugins: { blog: blogBackendPlugin(options?.hooks) },
+		plugins: {
+			blog: blogBackendPlugin(options?.hooks ? { hooks: options.hooks } : {}),
+		},
 		adapter: memoryAdapter,
 		...(options?.auth ? { auth: options.auth as never } : {}),
 	});
@@ -1128,15 +1130,17 @@ describe("Blog delete one-rule authorization tracer", () => {
 			basePath: "/api",
 			plugins: {
 				blog: blogBackendPlugin({
-					onBeforeDeletePost: () => {
-						ruleLifecycleEvents.push("before");
-					},
-					onPostDeleted: () => {
-						ruleLifecycleEvents.push("after");
-					},
-					onDeletePostError: () => {
-						ruleLifecycleEvents.push("error");
-						throw new Error("hook must not replace rule failure");
+					hooks: {
+						onBeforeDeletePost: () => {
+							ruleLifecycleEvents.push("before");
+						},
+						onPostDeleted: () => {
+							ruleLifecycleEvents.push("after");
+						},
+						onDeletePostError: () => {
+							ruleLifecycleEvents.push("error");
+							throw new Error("hook must not replace rule failure");
+						},
 					},
 				}),
 			},
@@ -1174,15 +1178,17 @@ describe("Blog delete one-rule authorization tracer", () => {
 			basePath: "/api",
 			plugins: {
 				blog: blogBackendPlugin({
-					onBeforeDeletePost: () => {
-						missingRuleLifecycleEvents.push("before");
-					},
-					onPostDeleted: () => {
-						missingRuleLifecycleEvents.push("after");
-					},
-					onDeletePostError: () => {
-						missingRuleLifecycleEvents.push("error");
-						throw new Error("hook must not replace missing-rule denial");
+					hooks: {
+						onBeforeDeletePost: () => {
+							missingRuleLifecycleEvents.push("before");
+						},
+						onPostDeleted: () => {
+							missingRuleLifecycleEvents.push("after");
+						},
+						onDeletePostError: () => {
+							missingRuleLifecycleEvents.push("error");
+							throw new Error("hook must not replace missing-rule denial");
+						},
 					},
 				}),
 			},

--- a/packages/stack/src/plugins/blog/api/plugin.ts
+++ b/packages/stack/src/plugins/blog/api/plugin.ts
@@ -134,11 +134,17 @@ function createBlogPrefetchForRoute(adapter: Adapter): BlogPrefetchForRoute {
  * Blog backend plugin. Every maintained HTTP endpoint adapts the same
  * operation exposed by `forRequest(request).api.blog` and `internal.blog`.
  */
-export const blogBackendPlugin = (hooks?: BlogBackendHooks) =>
+export interface BlogBackendOptions {
+	/** Post-authorization domain lifecycle hooks. */
+	hooks?: BlogBackendHooks;
+}
+
+export const blogBackendPlugin = (options: BlogBackendOptions = {}) =>
 	defineBackendPlugin({
-		name: "blog",
+		id: "blog",
 		dbPlugin: dbSchema,
-		operations: (adapter: Adapter) => createBlogOperations(adapter, hooks),
+		operations: (adapter: Adapter) =>
+			createBlogOperations(adapter, options.hooks),
 
 		/**
 		 * Explicit lower-level data API for SSG, jobs, and migration code.

--- a/packages/stack/src/plugins/cms/api/index.ts
+++ b/packages/stack/src/plugins/cms/api/index.ts
@@ -26,6 +26,7 @@ export {
 	CMSUpdateContentItemBodySchema,
 } from "./operations";
 export type {
+	CMSBackendConfig,
 	CMSBackendHooks,
 	CMSCreateOperationContext,
 	CMSCreateResultContext,

--- a/packages/stack/src/plugins/cms/api/plugin.ts
+++ b/packages/stack/src/plugins/cms/api/plugin.ts
@@ -210,7 +210,7 @@ export const cmsBackendPlugin = (config: CMSBackendConfig) => {
 		} as CMSPrefetchForRoute;
 
 	return defineBackendPlugin({
-		name: "cms",
+		id: "cms",
 		dbPlugin: dbSchema,
 		operations: (adapter: Adapter) =>
 			createCMSOperations(adapter, {

--- a/packages/stack/src/plugins/comments/__tests__/authorization.test.ts
+++ b/packages/stack/src/plugins/comments/__tests__/authorization.test.ts
@@ -8,7 +8,11 @@ import {
 	createServerAuth,
 	type ServerAuth,
 } from "../../../authorization/server";
-import { commentsBackendPlugin, type CommentsBackendOptions } from "../api";
+import {
+	commentsBackendPlugin,
+	type CommentsBackendHooks,
+	type CommentsBackendOptions,
+} from "../api";
 import { commentsPermissions } from "../permissions";
 import type { Comment, CommentLike } from "../types";
 
@@ -205,7 +209,7 @@ type CommentsOperationApi = ReturnType<
 
 type OperationScenario = {
 	readonly name: string;
-	readonly hook: keyof CommentsBackendOptions;
+	readonly hook: keyof CommentsBackendHooks;
 	readonly prepare: (
 		backend: ReturnType<typeof makeBackend>,
 	) => Promise<(api: CommentsOperationApi) => Promise<unknown>>;
@@ -442,7 +446,9 @@ describe("Comments protected-operation matrix", () => {
 			const lifecycle = vi.fn();
 			const backend = makeBackend({
 				auth: createModeratorOnlyAuth(),
-				plugin: { [scenario.hook]: lifecycle } as CommentsBackendOptions,
+				plugin: {
+					hooks: { [scenario.hook]: lifecycle } as CommentsBackendHooks,
+				},
 			});
 			const run = await scenario.prepare(backend);
 
@@ -491,7 +497,9 @@ describe("Comments protected-operation matrix", () => {
 				const lifecycle = vi.fn();
 				const backend = makeBackend({
 					auth,
-					plugin: { [scenario.hook]: lifecycle } as CommentsBackendOptions,
+					plugin: {
+						hooks: { [scenario.hook]: lifecycle } as CommentsBackendHooks,
+					},
 				});
 				const run = await scenario.prepare(backend);
 				await expect(
@@ -510,7 +518,9 @@ describe("Comments protected-operation matrix", () => {
 		async (scenario) => {
 			const lifecycle = vi.fn();
 			const backend = makeBackend({
-				plugin: { [scenario.hook]: lifecycle } as CommentsBackendOptions,
+				plugin: {
+					hooks: { [scenario.hook]: lifecycle } as CommentsBackendHooks,
+				},
 			});
 			const run = await scenario.prepare(backend);
 
@@ -533,7 +543,7 @@ describe("Comments protected-operation matrix", () => {
 		};
 		const backend = makeBackend({
 			auth: createModeratorOnlyAuth(),
-			plugin: hooks,
+			plugin: { hooks },
 		});
 		const api = backend.forRequest(
 			request("/comments", { identity: moderator }),
@@ -611,7 +621,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterApprove = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterApprove: afterApprove },
+			plugin: { hooks: { onAfterApprove: afterApprove } },
 		});
 		const pending = await seedComment(backend, { status: "pending" });
 		const updateMany = backend.adapter.updateMany.bind(backend.adapter);
@@ -670,7 +680,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterApprove = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterApprove: afterApprove },
+			plugin: { hooks: { onAfterApprove: afterApprove } },
 		});
 		const pending = await seedComment(backend, { status: "pending" });
 		vi.spyOn(backend.adapter, "updateMany").mockResolvedValue(result as never);
@@ -727,7 +737,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterApprove = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterApprove: afterApprove },
+			plugin: { hooks: { onAfterApprove: afterApprove } },
 		});
 		const pending = await seedComment(backend, { status: "pending" });
 		const updateMany = backend.adapter.updateMany.bind(backend.adapter);
@@ -778,7 +788,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterEdit = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterEdit: afterEdit },
+			plugin: { hooks: { onAfterEdit: afterEdit } },
 		});
 		const comment = await seedComment(backend);
 		const updateMany = backend.adapter.updateMany.bind(backend.adapter);
@@ -825,7 +835,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterEdit = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterEdit: afterEdit },
+			plugin: { hooks: { onAfterEdit: afterEdit } },
 		});
 		const comment = await seedComment(backend);
 		const updateMany = backend.adapter.updateMany.bind(backend.adapter);
@@ -953,7 +963,7 @@ describe("Comments protected-operation matrix", () => {
 		const afterDelete = vi.fn();
 		const backend = makeBackend({
 			auth: createAuth(),
-			plugin: { onAfterDelete: afterDelete },
+			plugin: { hooks: { onAfterDelete: afterDelete } },
 		});
 		const comment = await seedComment(backend);
 		const transaction = backend.adapter.transaction.bind(backend.adapter);
@@ -996,7 +1006,7 @@ describe("Comments operation-first authorization", () => {
 			auth: createAuth(),
 			plugin: {
 				autoApprove: true,
-				onBeforePost: vi.fn(),
+				hooks: { onBeforePost: vi.fn() },
 			},
 		});
 		const comment = await seedComment(backend);
@@ -1233,12 +1243,14 @@ describe("Comments operation-first authorization", () => {
 		backend = makeBackend({
 			auth: createAuth(),
 			plugin: {
-				onBeforeEdit: async (id) => {
-					await backend.adapter.update<Comment>({
-						model: "comment",
-						where: [{ field: "id", value: id }],
-						update: { authorId: viewer.id },
-					});
+				hooks: {
+					onBeforeEdit: async (id) => {
+						await backend.adapter.update<Comment>({
+							model: "comment",
+							where: [{ field: "id", value: id }],
+							update: { authorId: viewer.id },
+						});
+					},
 				},
 			},
 		});
@@ -1271,16 +1283,18 @@ describe("Comments operation-first authorization", () => {
 		const backend = makeBackend({
 			auth: createAuth(),
 			plugin: {
-				onBeforeEdit: (_id, _data, context) => {
-					events.push(
-						`before:${context.identity?.id}:${context.facts.authorId}`,
-					);
-					expect(Object.isFrozen(context)).toBe(true);
-					expect(Object.isFrozen(context.input)).toBe(true);
-				},
-				onAfterEdit: (result, context) => {
-					events.push(`after:${result.body}`);
-					expect(context.result).toBe(result);
+				hooks: {
+					onBeforeEdit: (_id, _data, context) => {
+						events.push(
+							`before:${context.identity?.id}:${context.facts.authorId}`,
+						);
+						expect(Object.isFrozen(context)).toBe(true);
+						expect(Object.isFrozen(context.input)).toBe(true);
+					},
+					onAfterEdit: (result, context) => {
+						events.push(`after:${result.body}`);
+						expect(context.result).toBe(result);
+					},
 				},
 			},
 		});
@@ -1325,7 +1339,7 @@ describe("Comments operation-first authorization", () => {
 			const lifecycle = vi.fn();
 			const backend = makeBackend({
 				auth,
-				plugin: { onBeforeDelete: lifecycle },
+				plugin: { hooks: { onBeforeDelete: lifecycle } },
 			});
 			const comment = await seedComment(backend);
 			await expect(
@@ -1354,12 +1368,14 @@ describe("Comments operation-first authorization", () => {
 		const backend = makeBackend({
 			auth: createAuth(getIdentity),
 			plugin: {
-				onBeforePost: (_input, context) => {
-					events.push(`before:${context.identity?.id ?? "internal"}`);
-				},
-				onAfterPost: (comment, context) => {
-					events.push(`after:${comment.authorId}`);
-					expect(context.result).toBe(comment);
+				hooks: {
+					onBeforePost: (_input, context) => {
+						events.push(`before:${context.identity?.id ?? "internal"}`);
+					},
+					onAfterPost: (comment, context) => {
+						events.push(`after:${comment.authorId}`);
+						expect(context.result).toBe(comment);
+					},
 				},
 			},
 		});

--- a/packages/stack/src/plugins/comments/api/operations.ts
+++ b/packages/stack/src/plugins/comments/api/operations.ts
@@ -236,8 +236,8 @@ export interface CommentsBackendHooks {
 	) => Promise<void> | void;
 }
 
-/** Configuration and lifecycle options for the Comments backend plugin. */
-export interface CommentsBackendOptions extends CommentsBackendHooks {
+/** Configuration for the Comments backend plugin. */
+export interface CommentsBackendOptions {
 	/** Automatically approve newly created comments. @default false */
 	autoApprove?: boolean;
 	/** Register the create-comment HTTP endpoint. @default true */
@@ -248,6 +248,8 @@ export interface CommentsBackendOptions extends CommentsBackendHooks {
 	resolveUser?: (
 		authorId: string,
 	) => Promise<{ name: string; avatarUrl?: string } | null>;
+	/** Post-authorization domain lifecycle hooks. */
+	hooks?: CommentsBackendHooks;
 }
 
 /** A domain/HTTP error raised after Comments input/fact validation. */
@@ -473,13 +475,13 @@ export function createCommentsOperations(
 		before: async (context) => {
 			const lifecycle = listContext(context);
 			if (context.input.authorId) {
-				await options.onBeforeListByAuthor?.(
+				await options.hooks?.onBeforeListByAuthor?.(
 					context.input.authorId,
 					context.input,
 					lifecycle,
 				);
 			}
-			await options.onBeforeList?.(context.input, lifecycle);
+			await options.hooks?.onBeforeList?.(context.input, lifecycle);
 		},
 		execute: async ({ input, identity }) =>
 			serializeCommentListResult(
@@ -499,7 +501,10 @@ export function createCommentsOperations(
 		permission: commentsPermissions.thread.read,
 		facts: ({ input }) => readFactsForCount(input),
 		before: async (context) => {
-			await options.onBeforeCount?.(context.input, countContext(context));
+			await options.hooks?.onBeforeCount?.(
+				context.input,
+				countContext(context),
+			);
 		},
 		execute: async ({ input }) => ({
 			count: await getCommentCount(adapter, input),
@@ -526,7 +531,7 @@ export function createCommentsOperations(
 				);
 			}
 			const { authorId: _trustedAuthorId, ...publicInput } = context.input;
-			await options.onBeforePost?.(publicInput, createContext(context));
+			await options.hooks?.onBeforePost?.(publicInput, createContext(context));
 		},
 		execute: async ({ input, identity }) => {
 			await assertReplyTarget(adapter, input);
@@ -543,7 +548,7 @@ export function createCommentsOperations(
 		},
 		after: async (context) => {
 			const base = createContext(context);
-			await options.onAfterPost?.(
+			await options.hooks?.onAfterPost?.(
 				context.result,
 				Object.freeze({ ...base, result: context.result }),
 			);
@@ -570,7 +575,7 @@ export function createCommentsOperations(
 					"COMMENT_EDITING_DISABLED",
 				);
 			}
-			await options.onBeforeEdit?.(
+			await options.hooks?.onBeforeEdit?.(
 				context.input.id,
 				context.input.data,
 				editContext(context),
@@ -599,7 +604,7 @@ export function createCommentsOperations(
 		},
 		after: async (context) => {
 			const base = editContext(context);
-			await options.onAfterEdit?.(
+			await options.hooks?.onAfterEdit?.(
 				context.result,
 				Object.freeze({ ...base, result: context.result }),
 			);
@@ -618,7 +623,7 @@ export function createCommentsOperations(
 				context.identity?.id,
 				context.input.authorId,
 			);
-			await options.onBeforeLike?.(
+			await options.hooks?.onBeforeLike?.(
 				context.input.id,
 				authorId,
 				reactContext(context),
@@ -651,7 +656,7 @@ export function createCommentsOperations(
 			};
 		},
 		before: async (context) => {
-			await options.onBeforeStatusChange?.(
+			await options.hooks?.onBeforeStatusChange?.(
 				context.input.id,
 				context.input.data.status,
 				moderateContext(context),
@@ -681,7 +686,7 @@ export function createCommentsOperations(
 		after: async (context) => {
 			if (context.input.data.status !== "approved") return;
 			const base = moderateContext(context);
-			await options.onAfterApprove?.(
+			await options.hooks?.onAfterApprove?.(
 				context.result,
 				Object.freeze({ ...base, result: context.result }),
 			);
@@ -696,7 +701,10 @@ export function createCommentsOperations(
 			return { commentId: comment.id, authorId: comment.authorId };
 		},
 		before: async (context) => {
-			await options.onBeforeDelete?.(context.input.id, deleteContext(context));
+			await options.hooks?.onBeforeDelete?.(
+				context.input.id,
+				deleteContext(context),
+			);
 		},
 		execute: async ({ input, facts }) => {
 			const deleted = await deleteCommentMutation(adapter, input.id, {
@@ -709,7 +717,7 @@ export function createCommentsOperations(
 		},
 		after: async (context) => {
 			const base = deleteContext(context);
-			await options.onAfterDelete?.(
+			await options.hooks?.onAfterDelete?.(
 				context.input.id,
 				Object.freeze({ ...base, result: context.result }),
 			);

--- a/packages/stack/src/plugins/comments/api/plugin.ts
+++ b/packages/stack/src/plugins/comments/api/plugin.ts
@@ -48,7 +48,7 @@ export const commentsBackendPlugin = (options: CommentsBackendOptions = {}) => {
 	const editingEnabled = options.allowEditing !== false;
 
 	return defineBackendPlugin({
-		name: "comments",
+		id: "comments",
 		dbPlugin: dbSchema,
 		operations: (adapter: Adapter) =>
 			createCommentsOperations(adapter, options),

--- a/packages/stack/src/plugins/form-builder/api/plugin.ts
+++ b/packages/stack/src/plugins/form-builder/api/plugin.ts
@@ -140,7 +140,7 @@ export const formBuilderBackendPlugin = (
 	config: FormBuilderBackendConfig = {},
 ) =>
 	defineBackendPlugin({
-		name: "form-builder",
+		id: "formBuilder",
 		dbPlugin: dbSchema,
 		operations: (adapter: Adapter) =>
 			createFormBuilderOperations(adapter, config.hooks),

--- a/packages/stack/src/plugins/kanban/__tests__/authorization.test.ts
+++ b/packages/stack/src/plugins/kanban/__tests__/authorization.test.ts
@@ -175,7 +175,11 @@ function makeBackend(options?: {
 }) {
 	return stack({
 		basePath: "/api",
-		plugins: { kanban: kanbanBackendPlugin(options?.hooks) },
+		plugins: {
+			kanban: kanbanBackendPlugin(
+				options?.hooks ? { hooks: options.hooks } : {},
+			),
+		},
 		adapter: options?.adapter ?? rawMemoryAdapter,
 		...(options?.auth ? { auth: options.auth as never } : {}),
 	});

--- a/packages/stack/src/plugins/kanban/api/index.ts
+++ b/packages/stack/src/plugins/kanban/api/index.ts
@@ -1,6 +1,7 @@
 export {
 	kanbanBackendPlugin,
 	type KanbanApiRouter,
+	type KanbanBackendOptions,
 	type KanbanRouteKey,
 } from "./plugin";
 export {

--- a/packages/stack/src/plugins/kanban/api/plugin.ts
+++ b/packages/stack/src/plugins/kanban/api/plugin.ts
@@ -23,6 +23,12 @@ import {
 import { KANBAN_QUERY_KEYS } from "./query-key-defs";
 import { serializeBoard, serializeBoardSummary } from "./serializers";
 
+/** Configuration for the Kanban backend plugin. */
+export interface KanbanBackendOptions {
+	/** Post-authorization domain lifecycle hooks. */
+	hooks?: KanbanBackendHooks;
+}
+
 export {
 	BoardIdOperationInputSchema,
 	ColumnIdOperationInputSchema,
@@ -83,11 +89,12 @@ function createKanbanPrefetchForRoute(
 }
 
 /** Kanban backend plugin backed by one operation inventory. */
-export const kanbanBackendPlugin = (hooks?: KanbanBackendHooks) =>
+export const kanbanBackendPlugin = (options: KanbanBackendOptions = {}) =>
 	defineBackendPlugin({
-		name: "kanban",
+		id: "kanban",
 		dbPlugin: dbSchema,
-		operations: (adapter: Adapter) => createKanbanOperations(adapter, hooks),
+		operations: (adapter: Adapter) =>
+			createKanbanOperations(adapter, options.hooks),
 
 		/** Lower-level server API that intentionally bypasses auth and hooks. */
 		api: (adapter: Adapter) => ({

--- a/packages/stack/src/plugins/media/api/plugin.ts
+++ b/packages/stack/src/plugins/media/api/plugin.ts
@@ -157,7 +157,7 @@ function parseMultipartFile(body: unknown) {
 /** Media backend plugin backed by one operation inventory. */
 export const mediaBackendPlugin = (config: MediaBackendConfig) =>
 	defineBackendPlugin({
-		name: "media",
+		id: "media",
 		dbPlugin: dbSchema,
 		operations: (adapter: Adapter) => createMediaOperations(adapter, config),
 

--- a/packages/stack/src/plugins/open-api/api/plugin.ts
+++ b/packages/stack/src/plugins/open-api/api/plugin.ts
@@ -180,14 +180,14 @@ function getScalarHTML(
  * // - GET /api/data/reference - Interactive Scalar UI
  * ```
  */
-export const openApiBackendPlugin = (options?: OpenAPIOptions) => {
-	const referencePath = options?.path ?? "/reference";
+export const openApiBackendPlugin = (options: OpenAPIOptions = {}) => {
+	const referencePath = options.path ?? "/reference";
 
 	// Store context for use in endpoint handlers
 	let storedContext: StackContext | null = null;
 
 	return defineBackendPlugin({
-		name: "open-api",
+		id: "openApi",
 		dbPlugin: openApiSchema,
 		infrastructureRoutes: OPEN_API_INFRASTRUCTURE_ROUTES,
 
@@ -208,9 +208,9 @@ export const openApiBackendPlugin = (options?: OpenAPIOptions) => {
 					}
 
 					const schema = generateOpenAPISchema(storedContext, {
-						title: options?.title,
-						description: options?.description,
-						version: options?.version,
+						title: options.title,
+						description: options.description,
+						version: options.version,
 					});
 
 					return schema;
@@ -223,7 +223,7 @@ export const openApiBackendPlugin = (options?: OpenAPIOptions) => {
 					method: "GET",
 				},
 				async (ctx) => {
-					if (options?.disableDefaultReference) {
+					if (options.disableDefaultReference) {
 						throw ctx.error(404, {
 							message: "Reference page is disabled",
 						});
@@ -236,13 +236,13 @@ export const openApiBackendPlugin = (options?: OpenAPIOptions) => {
 					}
 
 					const schema = generateOpenAPISchema(storedContext, {
-						title: options?.title,
-						description: options?.description,
-						version: options?.version,
+						title: options.title,
+						description: options.description,
+						version: options.version,
 					});
 
 					return new Response(
-						getScalarHTML(schema, options?.theme, options?.nonce),
+						getScalarHTML(schema, options.theme, options.nonce),
 						{
 							headers: {
 								"Content-Type": "text/html; charset=utf-8",

--- a/scripts/codegen/files/nextjs/lib/plugins/todo/api/backend.ts
+++ b/scripts/codegen/files/nextjs/lib/plugins/todo/api/backend.ts
@@ -25,92 +25,99 @@ const updateTodoOperationSchema = todoIdSchema.extend({
 });
 
 /** Generated Todo backend using the same operation for every server transport. */
-export const todosBackendPlugin = defineBackendPlugin({
-	name: "todos",
-	dbPlugin: dbSchema,
-	operations: (adapter) => ({
-		listTodos: defineOperation({
-			input: z.object({}),
-			permission: todoPermissions.todo.read,
-			facts: () => undefined,
-			execute: async () =>
-				(
-					await adapter.findMany<StoredTodo>({
+export const todosBackendPlugin = () =>
+	defineBackendPlugin({
+		id: "todos",
+		dbPlugin: dbSchema,
+		operations: (adapter) => ({
+			listTodos: defineOperation({
+				input: z.object({}),
+				permission: todoPermissions.todo.read,
+				facts: () => undefined,
+				execute: async () =>
+					(
+						await adapter.findMany<StoredTodo>({
+							model: "todo",
+							sortBy: { field: "createdAt", direction: "desc" },
+						})
+					).map(serializeTodo),
+			}),
+			createTodo: defineOperation({
+				input: createTodoSchema,
+				permission: todoPermissions.todo.create,
+				facts: () => undefined,
+				execute: async ({ input }) =>
+					serializeTodo(
+						await adapter.create<StoredTodo>({
+							model: "todo",
+							data: {
+								title: input.title,
+								completed: input.completed,
+								createdAt: new Date(),
+							},
+						}),
+					),
+			}),
+			updateTodo: defineOperation({
+				input: updateTodoOperationSchema,
+				permission: todoPermissions.todo.update,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					const updated = await adapter.update<StoredTodo>({
 						model: "todo",
-						sortBy: { field: "createdAt", direction: "desc" },
-					})
-				).map(serializeTodo),
-		}),
-		createTodo: defineOperation({
-			input: createTodoSchema,
-			permission: todoPermissions.todo.create,
-			facts: () => undefined,
-			execute: async ({ input }) =>
-				serializeTodo(
-					await adapter.create<StoredTodo>({
+						where: [{ field: "id", value: input.id }],
+						update: input.data,
+					});
+					if (!updated) {
+						throw new OperationHttpError(
+							404,
+							"Todo not found",
+							"TODO_NOT_FOUND",
+						);
+					}
+					return serializeTodo(updated);
+				},
+			}),
+			deleteTodo: defineOperation({
+				input: todoIdSchema,
+				permission: todoPermissions.todo.delete,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					await adapter.delete({
 						model: "todo",
-						data: {
-							title: input.title,
-							completed: input.completed,
-							createdAt: new Date(),
-						},
-					}),
-				),
+						where: [{ field: "id", value: input.id }],
+					});
+					return { success: true } as const;
+				},
+			}),
 		}),
-		updateTodo: defineOperation({
-			input: updateTodoOperationSchema,
-			permission: todoPermissions.todo.update,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				const updated = await adapter.update<StoredTodo>({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-					update: input.data,
-				});
-				if (!updated) {
-					throw new OperationHttpError(404, "Todo not found", "TODO_NOT_FOUND");
-				}
-				return serializeTodo(updated);
-			},
+		routes: (_adapter, _context, operations) => ({
+			listTodos: createEndpoint(
+				"/todos",
+				{ method: "GET", requireRequest: true },
+				operations.listTodos.route(() => ({})),
+			),
+			createTodo: createEndpoint(
+				"/todos",
+				{ method: "POST", body: createTodoSchema, requireRequest: true },
+				operations.createTodo.route((ctx) => ctx.body),
+			),
+			updateTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "PUT", body: updateTodoSchema, requireRequest: true },
+				operations.updateTodo.route((ctx) => ({
+					id: ctx.params.id,
+					data: ctx.body,
+				})),
+			),
+			deleteTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "DELETE", requireRequest: true },
+				operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
+			),
 		}),
-		deleteTodo: defineOperation({
-			input: todoIdSchema,
-			permission: todoPermissions.todo.delete,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				await adapter.delete({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-				});
-				return { success: true } as const;
-			},
-		}),
-	}),
-	routes: (_adapter, _context, operations) => ({
-		listTodos: createEndpoint(
-			"/todos",
-			{ method: "GET", requireRequest: true },
-			operations.listTodos.route(() => ({})),
-		),
-		createTodo: createEndpoint(
-			"/todos",
-			{ method: "POST", body: createTodoSchema, requireRequest: true },
-			operations.createTodo.route((ctx) => ctx.body),
-		),
-		updateTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "PUT", body: updateTodoSchema, requireRequest: true },
-			operations.updateTodo.route((ctx) => ({
-				id: ctx.params.id,
-				data: ctx.body,
-			})),
-		),
-		deleteTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "DELETE", requireRequest: true },
-			operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
-		),
-	}),
-});
+	});
 
-export type TodosApiRouter = ReturnType<typeof todosBackendPlugin.routes>;
+export type TodosApiRouter = ReturnType<
+	ReturnType<typeof todosBackendPlugin>["routes"]
+>;

--- a/scripts/codegen/files/nextjs/lib/stack-auth.ts
+++ b/scripts/codegen/files/nextjs/lib/stack-auth.ts
@@ -73,7 +73,7 @@ const blogLifecycleHooks: BlogBackendHooks = {
 const { handler, dbSchema } = stack({
 	basePath: "/api/example-auth",
 	auth: exampleServerAuth,
-	plugins: { blog: blogBackendPlugin(blogLifecycleHooks) },
+	plugins: { blog: blogBackendPlugin({ hooks: blogLifecycleHooks }) },
 	adapter: (db) => createMemoryAdapter(db)({}),
 });
 

--- a/scripts/codegen/files/nextjs/lib/stack.ts
+++ b/scripts/codegen/files/nextjs/lib/stack.ts
@@ -212,7 +212,7 @@ function createStack() {
 		basePath: "/api/data",
 		plugins: {
 			todos: todosBackendPlugin,
-			blog: blogBackendPlugin(blogHooks),
+			blog: blogBackendPlugin({ hooks: blogHooks }),
 			aiChat: aiChatBackendPlugin({
 				model: openai("gpt-4o"),
 				systemPrompt: `You are WealthReview — an AI-native financial intake assistant for a licensed investment advisory firm. Your job is to conduct a brief, natural intake conversation with clients and then submit a structured assessment for human advisor review via the submitIntakeAssessment tool.
@@ -360,60 +360,69 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 				resolveUser: async (authorId) => {
 					return { name: `User ${authorId}` };
 				},
-				onBeforeList: async (query, ctx) => {
-					if (query.status && query.status !== "approved") {
-						console.log("onBeforeList: reading moderation queue");
-					}
-				},
-				onBeforePost: async (input, ctx) => {
-					console.log(
-						"onBeforePost: new comment on",
-						input.resourceType,
-						input.resourceId,
-					);
-				},
-				onAfterPost: async (comment, ctx) => {
-					console.log(
-						"Comment created:",
-						comment.id,
-						"status:",
-						comment.status,
-					);
-				},
-				onBeforeEdit: async (commentId, update, ctx) => {
-					console.log("onBeforeEdit: comment", commentId);
-				},
-				onBeforeLike: async (commentId, authorId, ctx) => {
-					console.log(
-						"onBeforeLike: user",
-						authorId,
-						"toggling like on comment",
-						commentId,
-					);
-				},
-				onBeforeStatusChange: async (commentId, status, ctx) => {
-					console.log("onBeforeStatusChange: comment", commentId, "->", status);
-				},
-				onAfterApprove: async (comment, ctx) => {
-					console.log("Comment approved:", comment.id);
-				},
-				onBeforeDelete: async (commentId, ctx) => {
-					console.log("onBeforeDelete: comment", commentId);
-				},
-				onAfterDelete: async (commentId, ctx) => {
-					console.log("Comment deleted:", commentId);
+				hooks: {
+					onBeforeList: async (query, ctx) => {
+						if (query.status && query.status !== "approved") {
+							console.log("onBeforeList: reading moderation queue");
+						}
+					},
+					onBeforePost: async (input, ctx) => {
+						console.log(
+							"onBeforePost: new comment on",
+							input.resourceType,
+							input.resourceId,
+						);
+					},
+					onAfterPost: async (comment, ctx) => {
+						console.log(
+							"Comment created:",
+							comment.id,
+							"status:",
+							comment.status,
+						);
+					},
+					onBeforeEdit: async (commentId, update, ctx) => {
+						console.log("onBeforeEdit: comment", commentId);
+					},
+					onBeforeLike: async (commentId, authorId, ctx) => {
+						console.log(
+							"onBeforeLike: user",
+							authorId,
+							"toggling like on comment",
+							commentId,
+						);
+					},
+					onBeforeStatusChange: async (commentId, status, ctx) => {
+						console.log(
+							"onBeforeStatusChange: comment",
+							commentId,
+							"->",
+							status,
+						);
+					},
+					onAfterApprove: async (comment, ctx) => {
+						console.log("Comment approved:", comment.id);
+					},
+					onBeforeDelete: async (commentId, ctx) => {
+						console.log("onBeforeDelete: comment", commentId);
+					},
+					onAfterDelete: async (commentId, ctx) => {
+						console.log("Comment deleted:", commentId);
+					},
 				},
 			}),
 			kanban: kanbanBackendPlugin({
-				onBeforeListBoards: async (filter, context) => {
-					console.log("onBeforeListBoards hook called", filter);
-				},
-				onBeforeCreateBoard: async (data, context) => {
-					console.log("onBeforeCreateBoard hook called", data.name);
-				},
-				onBoardCreated: async (board, context) => {
-					console.log("Board created:", board.id, board.name);
-					revalidatePath("/pages/ssg-kanban", "page");
+				hooks: {
+					onBeforeListBoards: async (filter, context) => {
+						console.log("onBeforeListBoards hook called", filter);
+					},
+					onBeforeCreateBoard: async (data, context) => {
+						console.log("onBeforeCreateBoard hook called", data.name);
+					},
+					onBoardCreated: async (board, context) => {
+						console.log("Board created:", board.id, board.name);
+						revalidatePath("/pages/ssg-kanban", "page");
+					},
 				},
 			}),
 			media: mediaBackendPlugin({

--- a/scripts/codegen/files/nextjs/lib/stack.ts
+++ b/scripts/codegen/files/nextjs/lib/stack.ts
@@ -211,7 +211,7 @@ function createStack() {
 	const s = stack({
 		basePath: "/api/data",
 		plugins: {
-			todos: todosBackendPlugin,
+			todos: todosBackendPlugin(),
 			blog: blogBackendPlugin({ hooks: blogHooks }),
 			aiChat: aiChatBackendPlugin({
 				model: openai("gpt-4o"),

--- a/scripts/codegen/files/react-router/app/lib/plugins/todo/api/backend.ts
+++ b/scripts/codegen/files/react-router/app/lib/plugins/todo/api/backend.ts
@@ -25,92 +25,99 @@ const updateTodoOperationSchema = todoIdSchema.extend({
 });
 
 /** Generated Todo backend using the same operation for every server transport. */
-export const todosBackendPlugin = defineBackendPlugin({
-	name: "todos",
-	dbPlugin: dbSchema,
-	operations: (adapter) => ({
-		listTodos: defineOperation({
-			input: z.object({}),
-			permission: todoPermissions.todo.read,
-			facts: () => undefined,
-			execute: async () =>
-				(
-					await adapter.findMany<StoredTodo>({
+export const todosBackendPlugin = () =>
+	defineBackendPlugin({
+		id: "todos",
+		dbPlugin: dbSchema,
+		operations: (adapter) => ({
+			listTodos: defineOperation({
+				input: z.object({}),
+				permission: todoPermissions.todo.read,
+				facts: () => undefined,
+				execute: async () =>
+					(
+						await adapter.findMany<StoredTodo>({
+							model: "todo",
+							sortBy: { field: "createdAt", direction: "desc" },
+						})
+					).map(serializeTodo),
+			}),
+			createTodo: defineOperation({
+				input: createTodoSchema,
+				permission: todoPermissions.todo.create,
+				facts: () => undefined,
+				execute: async ({ input }) =>
+					serializeTodo(
+						await adapter.create<StoredTodo>({
+							model: "todo",
+							data: {
+								title: input.title,
+								completed: input.completed,
+								createdAt: new Date(),
+							},
+						}),
+					),
+			}),
+			updateTodo: defineOperation({
+				input: updateTodoOperationSchema,
+				permission: todoPermissions.todo.update,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					const updated = await adapter.update<StoredTodo>({
 						model: "todo",
-						sortBy: { field: "createdAt", direction: "desc" },
-					})
-				).map(serializeTodo),
-		}),
-		createTodo: defineOperation({
-			input: createTodoSchema,
-			permission: todoPermissions.todo.create,
-			facts: () => undefined,
-			execute: async ({ input }) =>
-				serializeTodo(
-					await adapter.create<StoredTodo>({
+						where: [{ field: "id", value: input.id }],
+						update: input.data,
+					});
+					if (!updated) {
+						throw new OperationHttpError(
+							404,
+							"Todo not found",
+							"TODO_NOT_FOUND",
+						);
+					}
+					return serializeTodo(updated);
+				},
+			}),
+			deleteTodo: defineOperation({
+				input: todoIdSchema,
+				permission: todoPermissions.todo.delete,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					await adapter.delete({
 						model: "todo",
-						data: {
-							title: input.title,
-							completed: input.completed,
-							createdAt: new Date(),
-						},
-					}),
-				),
+						where: [{ field: "id", value: input.id }],
+					});
+					return { success: true } as const;
+				},
+			}),
 		}),
-		updateTodo: defineOperation({
-			input: updateTodoOperationSchema,
-			permission: todoPermissions.todo.update,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				const updated = await adapter.update<StoredTodo>({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-					update: input.data,
-				});
-				if (!updated) {
-					throw new OperationHttpError(404, "Todo not found", "TODO_NOT_FOUND");
-				}
-				return serializeTodo(updated);
-			},
+		routes: (_adapter, _context, operations) => ({
+			listTodos: createEndpoint(
+				"/todos",
+				{ method: "GET", requireRequest: true },
+				operations.listTodos.route(() => ({})),
+			),
+			createTodo: createEndpoint(
+				"/todos",
+				{ method: "POST", body: createTodoSchema, requireRequest: true },
+				operations.createTodo.route((ctx) => ctx.body),
+			),
+			updateTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "PUT", body: updateTodoSchema, requireRequest: true },
+				operations.updateTodo.route((ctx) => ({
+					id: ctx.params.id,
+					data: ctx.body,
+				})),
+			),
+			deleteTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "DELETE", requireRequest: true },
+				operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
+			),
 		}),
-		deleteTodo: defineOperation({
-			input: todoIdSchema,
-			permission: todoPermissions.todo.delete,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				await adapter.delete({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-				});
-				return { success: true } as const;
-			},
-		}),
-	}),
-	routes: (_adapter, _context, operations) => ({
-		listTodos: createEndpoint(
-			"/todos",
-			{ method: "GET", requireRequest: true },
-			operations.listTodos.route(() => ({})),
-		),
-		createTodo: createEndpoint(
-			"/todos",
-			{ method: "POST", body: createTodoSchema, requireRequest: true },
-			operations.createTodo.route((ctx) => ctx.body),
-		),
-		updateTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "PUT", body: updateTodoSchema, requireRequest: true },
-			operations.updateTodo.route((ctx) => ({
-				id: ctx.params.id,
-				data: ctx.body,
-			})),
-		),
-		deleteTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "DELETE", requireRequest: true },
-			operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
-		),
-	}),
-});
+	});
 
-export type TodosApiRouter = ReturnType<typeof todosBackendPlugin.routes>;
+export type TodosApiRouter = ReturnType<
+	ReturnType<typeof todosBackendPlugin>["routes"]
+>;

--- a/scripts/codegen/files/react-router/app/lib/stack-auth.ts
+++ b/scripts/codegen/files/react-router/app/lib/stack-auth.ts
@@ -70,7 +70,7 @@ const blogLifecycleHooks: BlogBackendHooks = {
 const { handler, dbSchema } = stack({
 	basePath: "/api/example-auth",
 	auth: exampleServerAuth,
-	plugins: { blog: blogBackendPlugin(blogLifecycleHooks) },
+	plugins: { blog: blogBackendPlugin({ hooks: blogLifecycleHooks }) },
 	adapter: (db) => createMemoryAdapter(db)({}),
 });
 

--- a/scripts/codegen/files/react-router/app/lib/stack.ts
+++ b/scripts/codegen/files/react-router/app/lib/stack.ts
@@ -207,7 +207,7 @@ _stackRef = stack({
 	basePath: "/api/data",
 	auth: serverAuth,
 	plugins: {
-		todos: todosBackendPlugin,
+		todos: todosBackendPlugin(),
 		blog: blogBackendPlugin({ hooks: blogHooks }),
 		aiChat: aiChatBackendPlugin({
 			model: openai("gpt-4o"),

--- a/scripts/codegen/files/react-router/app/lib/stack.ts
+++ b/scripts/codegen/files/react-router/app/lib/stack.ts
@@ -208,7 +208,7 @@ _stackRef = stack({
 	auth: serverAuth,
 	plugins: {
 		todos: todosBackendPlugin,
-		blog: blogBackendPlugin(blogHooks),
+		blog: blogBackendPlugin({ hooks: blogHooks }),
 		aiChat: aiChatBackendPlugin({
 			model: openai("gpt-4o"),
 			systemPrompt: `You are WealthReview — an AI-native financial intake assistant for a licensed investment advisory firm. Your job is to conduct a brief, natural intake conversation with clients and then submit a structured assessment for human advisor review via the submitIntakeAssessment tool.
@@ -313,11 +313,13 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			theme: "kepler",
 		}),
 		kanban: kanbanBackendPlugin({
-			onBeforeListBoards: async (filter, context) => {
-				console.log("onBeforeListBoards hook called", filter);
-			},
-			onBoardCreated: async (board, context) => {
-				console.log("Board created:", board.id, board.name);
+			hooks: {
+				onBeforeListBoards: async (filter, context) => {
+					console.log("onBeforeListBoards hook called", filter);
+				},
+				onBoardCreated: async (board, context) => {
+					console.log("Board created:", board.id, board.name);
+				},
 			},
 		}),
 		comments: commentsBackendPlugin({
@@ -325,34 +327,36 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			resolveUser: async (authorId) => {
 				return { name: `User ${authorId}` };
 			},
-			onBeforeList: async (query, ctx) => {
-				if (query.status && query.status !== "approved") {
-					console.log("onBeforeList: reading moderation queue");
-				}
-			},
-			onBeforePost: async (input, ctx) => {
-				console.log(
-					"onBeforePost: new comment on",
-					input.resourceType,
-					input.resourceId,
-				);
-			},
-			onBeforeEdit: async (commentId, update, ctx) => {
-				console.log("onBeforeEdit: comment", commentId);
-			},
-			onBeforeLike: async (commentId, authorId, ctx) => {
-				console.log(
-					"onBeforeLike: user",
-					authorId,
-					"toggling like on comment",
-					commentId,
-				);
-			},
-			onBeforeStatusChange: async (commentId, status, ctx) => {
-				console.log("onBeforeStatusChange: comment", commentId, "->", status);
-			},
-			onBeforeDelete: async (commentId, ctx) => {
-				console.log("onBeforeDelete: comment", commentId);
+			hooks: {
+				onBeforeList: async (query, ctx) => {
+					if (query.status && query.status !== "approved") {
+						console.log("onBeforeList: reading moderation queue");
+					}
+				},
+				onBeforePost: async (input, ctx) => {
+					console.log(
+						"onBeforePost: new comment on",
+						input.resourceType,
+						input.resourceId,
+					);
+				},
+				onBeforeEdit: async (commentId, update, ctx) => {
+					console.log("onBeforeEdit: comment", commentId);
+				},
+				onBeforeLike: async (commentId, authorId, ctx) => {
+					console.log(
+						"onBeforeLike: user",
+						authorId,
+						"toggling like on comment",
+						commentId,
+					);
+				},
+				onBeforeStatusChange: async (commentId, status, ctx) => {
+					console.log("onBeforeStatusChange: comment", commentId, "->", status);
+				},
+				onBeforeDelete: async (commentId, ctx) => {
+					console.log("onBeforeDelete: comment", commentId);
+				},
 			},
 		}),
 		media: mediaBackendPlugin({

--- a/scripts/codegen/files/tanstack/src/lib/plugins/todo/api/backend.ts
+++ b/scripts/codegen/files/tanstack/src/lib/plugins/todo/api/backend.ts
@@ -25,92 +25,99 @@ const updateTodoOperationSchema = todoIdSchema.extend({
 });
 
 /** Generated Todo backend using the same operation for every server transport. */
-export const todosBackendPlugin = defineBackendPlugin({
-	name: "todos",
-	dbPlugin: dbSchema,
-	operations: (adapter) => ({
-		listTodos: defineOperation({
-			input: z.object({}),
-			permission: todoPermissions.todo.read,
-			facts: () => undefined,
-			execute: async () =>
-				(
-					await adapter.findMany<StoredTodo>({
+export const todosBackendPlugin = () =>
+	defineBackendPlugin({
+		id: "todos",
+		dbPlugin: dbSchema,
+		operations: (adapter) => ({
+			listTodos: defineOperation({
+				input: z.object({}),
+				permission: todoPermissions.todo.read,
+				facts: () => undefined,
+				execute: async () =>
+					(
+						await adapter.findMany<StoredTodo>({
+							model: "todo",
+							sortBy: { field: "createdAt", direction: "desc" },
+						})
+					).map(serializeTodo),
+			}),
+			createTodo: defineOperation({
+				input: createTodoSchema,
+				permission: todoPermissions.todo.create,
+				facts: () => undefined,
+				execute: async ({ input }) =>
+					serializeTodo(
+						await adapter.create<StoredTodo>({
+							model: "todo",
+							data: {
+								title: input.title,
+								completed: input.completed,
+								createdAt: new Date(),
+							},
+						}),
+					),
+			}),
+			updateTodo: defineOperation({
+				input: updateTodoOperationSchema,
+				permission: todoPermissions.todo.update,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					const updated = await adapter.update<StoredTodo>({
 						model: "todo",
-						sortBy: { field: "createdAt", direction: "desc" },
-					})
-				).map(serializeTodo),
-		}),
-		createTodo: defineOperation({
-			input: createTodoSchema,
-			permission: todoPermissions.todo.create,
-			facts: () => undefined,
-			execute: async ({ input }) =>
-				serializeTodo(
-					await adapter.create<StoredTodo>({
+						where: [{ field: "id", value: input.id }],
+						update: input.data,
+					});
+					if (!updated) {
+						throw new OperationHttpError(
+							404,
+							"Todo not found",
+							"TODO_NOT_FOUND",
+						);
+					}
+					return serializeTodo(updated);
+				},
+			}),
+			deleteTodo: defineOperation({
+				input: todoIdSchema,
+				permission: todoPermissions.todo.delete,
+				facts: ({ input }) => ({ id: input.id }),
+				execute: async ({ input }) => {
+					await adapter.delete({
 						model: "todo",
-						data: {
-							title: input.title,
-							completed: input.completed,
-							createdAt: new Date(),
-						},
-					}),
-				),
+						where: [{ field: "id", value: input.id }],
+					});
+					return { success: true } as const;
+				},
+			}),
 		}),
-		updateTodo: defineOperation({
-			input: updateTodoOperationSchema,
-			permission: todoPermissions.todo.update,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				const updated = await adapter.update<StoredTodo>({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-					update: input.data,
-				});
-				if (!updated) {
-					throw new OperationHttpError(404, "Todo not found", "TODO_NOT_FOUND");
-				}
-				return serializeTodo(updated);
-			},
+		routes: (_adapter, _context, operations) => ({
+			listTodos: createEndpoint(
+				"/todos",
+				{ method: "GET", requireRequest: true },
+				operations.listTodos.route(() => ({})),
+			),
+			createTodo: createEndpoint(
+				"/todos",
+				{ method: "POST", body: createTodoSchema, requireRequest: true },
+				operations.createTodo.route((ctx) => ctx.body),
+			),
+			updateTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "PUT", body: updateTodoSchema, requireRequest: true },
+				operations.updateTodo.route((ctx) => ({
+					id: ctx.params.id,
+					data: ctx.body,
+				})),
+			),
+			deleteTodo: createEndpoint(
+				"/todos/:id",
+				{ method: "DELETE", requireRequest: true },
+				operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
+			),
 		}),
-		deleteTodo: defineOperation({
-			input: todoIdSchema,
-			permission: todoPermissions.todo.delete,
-			facts: ({ input }) => ({ id: input.id }),
-			execute: async ({ input }) => {
-				await adapter.delete({
-					model: "todo",
-					where: [{ field: "id", value: input.id }],
-				});
-				return { success: true } as const;
-			},
-		}),
-	}),
-	routes: (_adapter, _context, operations) => ({
-		listTodos: createEndpoint(
-			"/todos",
-			{ method: "GET", requireRequest: true },
-			operations.listTodos.route(() => ({})),
-		),
-		createTodo: createEndpoint(
-			"/todos",
-			{ method: "POST", body: createTodoSchema, requireRequest: true },
-			operations.createTodo.route((ctx) => ctx.body),
-		),
-		updateTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "PUT", body: updateTodoSchema, requireRequest: true },
-			operations.updateTodo.route((ctx) => ({
-				id: ctx.params.id,
-				data: ctx.body,
-			})),
-		),
-		deleteTodo: createEndpoint(
-			"/todos/:id",
-			{ method: "DELETE", requireRequest: true },
-			operations.deleteTodo.route((ctx) => ({ id: ctx.params.id })),
-		),
-	}),
-});
+	});
 
-export type TodosApiRouter = ReturnType<typeof todosBackendPlugin.routes>;
+export type TodosApiRouter = ReturnType<
+	ReturnType<typeof todosBackendPlugin>["routes"]
+>;

--- a/scripts/codegen/files/tanstack/src/lib/stack-auth.ts
+++ b/scripts/codegen/files/tanstack/src/lib/stack-auth.ts
@@ -70,7 +70,7 @@ const blogLifecycleHooks: BlogBackendHooks = {
 const { handler, dbSchema } = stack({
 	basePath: "/api/example-auth",
 	auth: exampleServerAuth,
-	plugins: { blog: blogBackendPlugin(blogLifecycleHooks) },
+	plugins: { blog: blogBackendPlugin({ hooks: blogLifecycleHooks }) },
 	adapter: (db) => createMemoryAdapter(db)({}),
 });
 

--- a/scripts/codegen/files/tanstack/src/lib/stack.ts
+++ b/scripts/codegen/files/tanstack/src/lib/stack.ts
@@ -207,7 +207,7 @@ _stackRef = stack({
 	basePath: "/api/data",
 	auth: serverAuth,
 	plugins: {
-		todos: todosBackendPlugin,
+		todos: todosBackendPlugin(),
 		blog: blogBackendPlugin({ hooks: blogHooks }),
 		aiChat: aiChatBackendPlugin({
 			model: openai("gpt-4o"),

--- a/scripts/codegen/files/tanstack/src/lib/stack.ts
+++ b/scripts/codegen/files/tanstack/src/lib/stack.ts
@@ -208,7 +208,7 @@ _stackRef = stack({
 	auth: serverAuth,
 	plugins: {
 		todos: todosBackendPlugin,
-		blog: blogBackendPlugin(blogHooks),
+		blog: blogBackendPlugin({ hooks: blogHooks }),
 		aiChat: aiChatBackendPlugin({
 			model: openai("gpt-4o"),
 			systemPrompt: `You are WealthReview — an AI-native financial intake assistant for a licensed investment advisory firm. Your job is to conduct a brief, natural intake conversation with clients and then submit a structured assessment for human advisor review via the submitIntakeAssessment tool.
@@ -313,11 +313,13 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			theme: "kepler",
 		}),
 		kanban: kanbanBackendPlugin({
-			onBeforeListBoards: async (filter, context) => {
-				console.log("onBeforeListBoards hook called", filter);
-			},
-			onBoardCreated: async (board, context) => {
-				console.log("Board created:", board.id, board.name);
+			hooks: {
+				onBeforeListBoards: async (filter, context) => {
+					console.log("onBeforeListBoards hook called", filter);
+				},
+				onBoardCreated: async (board, context) => {
+					console.log("Board created:", board.id, board.name);
+				},
 			},
 		}),
 		comments: commentsBackendPlugin({
@@ -325,34 +327,36 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			resolveUser: async (authorId) => {
 				return { name: `User ${authorId}` };
 			},
-			onBeforeList: async (query, ctx) => {
-				if (query.status && query.status !== "approved") {
-					console.log("onBeforeList: reading moderation queue");
-				}
-			},
-			onBeforePost: async (input, ctx) => {
-				console.log(
-					"onBeforePost: new comment on",
-					input.resourceType,
-					input.resourceId,
-				);
-			},
-			onBeforeEdit: async (commentId, update, ctx) => {
-				console.log("onBeforeEdit: comment", commentId);
-			},
-			onBeforeLike: async (commentId, authorId, ctx) => {
-				console.log(
-					"onBeforeLike: user",
-					authorId,
-					"toggling like on comment",
-					commentId,
-				);
-			},
-			onBeforeStatusChange: async (commentId, status, ctx) => {
-				console.log("onBeforeStatusChange: comment", commentId, "->", status);
-			},
-			onBeforeDelete: async (commentId, ctx) => {
-				console.log("onBeforeDelete: comment", commentId);
+			hooks: {
+				onBeforeList: async (query, ctx) => {
+					if (query.status && query.status !== "approved") {
+						console.log("onBeforeList: reading moderation queue");
+					}
+				},
+				onBeforePost: async (input, ctx) => {
+					console.log(
+						"onBeforePost: new comment on",
+						input.resourceType,
+						input.resourceId,
+					);
+				},
+				onBeforeEdit: async (commentId, update, ctx) => {
+					console.log("onBeforeEdit: comment", commentId);
+				},
+				onBeforeLike: async (commentId, authorId, ctx) => {
+					console.log(
+						"onBeforeLike: user",
+						authorId,
+						"toggling like on comment",
+						commentId,
+					);
+				},
+				onBeforeStatusChange: async (commentId, status, ctx) => {
+					console.log("onBeforeStatusChange: comment", commentId, "->", status);
+				},
+				onBeforeDelete: async (commentId, ctx) => {
+					console.log("onBeforeDelete: comment", commentId);
+				},
 			},
 		}),
 		media: mediaBackendPlugin({


### PR DESCRIPTION
Closes #217

## Summary

- gives all eight first-party backend definitions their canonical camelCase literal IDs
- normalizes optional Blog and Kanban lifecycle configuration to `{ hooks }`, nests Comments lifecycle callbacks under `hooks`, and retains zero-argument calls for optional-only factories
- preserves required AI model, CMS content types, and Media storage dependencies plus existing domain field names and behavior
- updates maintained generated integrations and parity tests to use the canonical options-object form
- adds runtime and compile-time factory contracts covering IDs, zero-config calls, required-config failures, nested hooks, public option types, and a consumer-defined zero-config factory

## Scope reconciliation

The issue's abbreviated example placed `resolveUser` / `searchUsers` on the Kanban backend and shortened Media's `storageAdapter` / `resolveTenantId` names. Those are intentionally not implemented as literal renames: Kanban's user resolvers are browser provider overrides with no backend consumer, while Media's names describe established storage and tenant contracts. Adding ignored backend fields or renaming those protocols would conflict with the issue's non-goal of preserving business/storage behavior. Kanban therefore uses `kanbanBackendPlugin({ hooks })`; Media preserves `storageAdapter` and `resolveTenantId` beside `hooks`.

Lifecycle callback names and execution order, authorization/trust behavior, route slugs, DB namespaces, operation IDs, and permission descriptor IDs are unchanged.

## Verification

- `pnpm build` (Node 22)
- `pnpm typecheck` (Node 22)
- `pnpm lint` (Node 22)
- `pnpm --filter @btst/stack knip` (strict, Node 22)
- `pnpm --filter @btst/stack exec vitest run` — 72 files / 904 tests
