### PR TITLE
feat(stack): normalize AI Chat lifecycle vocabulary

### DIFF
--- a/.agents/skills/btst-backend-plugin-dev/SKILL.md
+++ b/.agents/skills/btst-backend-plugin-dev/SKILL.md
@@ -40,19 +40,21 @@ src/plugins/{name}/
 
 ## Lifecycle hook naming
 
-Pattern: `onBefore{Entity}{Action}`, `onAfter{Entity}{Action}`, `on{Entity}{Action}Error`
+Pattern: `onBefore{Action}{Entity}`, `onAfter{Action}{Entity}`, `onError{Action}{Entity}`
 
 ```typescript
-// Examples from existing plugins:
-onBeforeListPosts, onPostsRead, onListPostsError
-onBeforeCreatePost, onPostCreated, onCreatePostError
-onBeforeUpdatePost, onPostUpdated, onUpdatePostError
-onBeforeDeletePost, onPostDeleted, onDeletePostError
-onBeforePost, onAfterPost          // comments plugin (create comment)
-onBeforeEdit, onAfterEdit          // comments plugin (edit comment)
-onBeforeDelete, onAfterDelete      // comments plugin (delete comment)
-onBeforeStatusChange, onAfterApprove
+onBeforeListPosts, onAfterListPosts, onErrorListPosts
+onBeforeCreatePost, onAfterCreatePost, onErrorCreatePost
+onBeforeUpdatePost, onAfterUpdatePost, onErrorUpdatePost
+onBeforeDeletePost, onAfterDeletePost, onErrorDeletePost
+
+// Preserve meaningful domain events instead of inventing CRUD phases.
+onBeforeChat, onAfterChat, onErrorChat
+onBeforeActivateTools
 ```
+
+Normalize names without adding lifecycle phases that the plugin does not
+already support.
 
 ## Trusted operations in AI tool execute functions
 

--- a/.agents/skills/btst-integration/REFERENCE.md
+++ b/.agents/skills/btst-integration/REFERENCE.md
@@ -420,9 +420,9 @@ aiChatBackendPlugin({
   tools: { myTool },
   enablePageTools: true,
   hooks: {
-    onConversationCreated: async (convo) => { /* … */ },
+    onAfterCreateConversation: async (convo) => { /* … */ },
     onAfterChat: async (conversationId, messages) => { /* … */ },
-    onBeforeToolsActivated: async (toolNames, routeName, ctx) => toolNames,
+    onBeforeActivateTools: async (toolNames, routeName, ctx) => toolNames,
   },
 })
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,11 +169,11 @@ export const myClientPlugin = (config: MyClientConfig) =>
 
 ```typescript
 // Authorization hooks (throw to deny)
-onBeforeCreate, onBeforeUpdate, onBeforeDelete, onBeforeList
+onBeforeCreateItem, onBeforeUpdateItem, onBeforeDeleteItem, onBeforeListItems
 // Lifecycle hooks (called after success)
-onAfterCreate, onAfterUpdate, onAfterDelete, onAfterList
+onAfterCreateItem, onAfterUpdateItem, onAfterDeleteItem, onAfterListItems
 // Error hooks
-onCreateError, onUpdateError, onDeleteError, onListError
+onErrorCreateItem, onErrorUpdateItem, onErrorDeleteItem, onErrorListItems
 ```
 
 ---
@@ -322,9 +322,9 @@ import { createItemSchema, updateItemSchema } from "../schemas"
 import { listItems, getItemById } from "./getters"
 
 export interface MyBackendHooks {
-  onBeforeCreate?: (data: unknown, ctx: { headers: Headers }) => Promise<void> | void
-  onAfterCreate?: (item: unknown, ctx: { headers: Headers }) => Promise<void> | void
-  onCreateError?: (error: Error, ctx: { headers: Headers }) => Promise<void> | void
+  onBeforeCreateItem?: (data: unknown, ctx: { headers: Headers }) => Promise<void> | void
+  onAfterCreateItem?: (item: unknown, ctx: { headers: Headers }) => Promise<void> | void
+  onErrorCreateItem?: (error: Error, ctx: { headers: Headers }) => Promise<void> | void
 }
 
 export const myBackendPlugin = (hooks?: MyBackendHooks) =>
@@ -346,15 +346,15 @@ export const myBackendPlugin = (hooks?: MyBackendHooks) =>
         "/items",
         { method: "POST", body: createItemSchema },
         async (ctx) => {
-          if (hooks?.onBeforeCreate) {
+          if (hooks?.onBeforeCreateItem) {
             try {
-              await hooks.onBeforeCreate(ctx.body, { headers: ctx.headers })
+              await hooks.onBeforeCreateItem(ctx.body, { headers: ctx.headers })
             } catch (e) {
               throw ctx.error(403, { message: e instanceof Error ? e.message : "Unauthorized" })
             }
           }
           const item = await adapter.create({ model: "item", data: { ...ctx.body, createdAt: new Date(), updatedAt: new Date() } })
-          await hooks?.onAfterCreate?.(item, { headers: ctx.headers })
+          await hooks?.onAfterCreateItem?.(item, { headers: ctx.headers })
           return item
         },
       )

--- a/docs/content/docs/plugins/ai-chat.mdx
+++ b/docs/content/docs/plugins/ai-chat.mdx
@@ -488,6 +488,23 @@ Customize post-authorization domain behavior with optional lifecycle hooks. Keep
 
 <AutoTypeTable path="../packages/stack/src/plugins/ai-chat/api/plugin.ts" name="AiChatBackendHooks" />
 
+AI Chat lifecycle names use the action-first `onBefore<Action><Entity>`, `onAfter<Action><Entity>`, and `onError<Action><Entity>` grammar. Chat completion remains the domain event `onAfterChat`.
+
+| Before RC3 | RC3 |
+|---|---|
+| `onBeforeToolsActivated` | `onBeforeActivateTools` |
+| `onConversationsRead` | `onAfterListConversations` |
+| `onConversationRead` | `onAfterGetConversation` |
+| `onConversationCreated` | `onAfterCreateConversation` |
+| `onConversationUpdated` | `onAfterUpdateConversation` |
+| `onConversationDeleted` | `onAfterDeleteConversation` |
+| `onChatError` | `onErrorChat` |
+| `onListConversationsError` | `onErrorListConversations` |
+| `onGetConversationError` | `onErrorGetConversation` |
+| `onCreateConversationError` | `onErrorCreateConversation` |
+| `onUpdateConversationError` | `onErrorUpdateConversation` |
+| `onDeleteConversationError` | `onErrorDeleteConversation` |
+
 **Example usage:**
 
 ```ts title="lib/stack.ts"

--- a/docs/content/docs/plugins/ai-chat.mdx
+++ b/docs/content/docs/plugins/ai-chat.mdx
@@ -499,14 +499,14 @@ const chatHooks: AiChatBackendHooks = {
     enforceRateLimit(context.headers)
   },
   // Lifecycle hooks
-  onConversationCreated(conversation, context) {
+  onAfterCreateConversation(conversation, context) {
     console.log("Conversation created:", conversation.id)
   },
   onAfterChat(conversationId, messages, context) {
     console.log("Chat completed:", conversationId, "messages:", messages.length)
   },
   // Error hooks
-  onChatError(error, context) {
+  onErrorChat(error, context) {
     console.error("Chat error:", error.message)
   },
 }
@@ -1295,11 +1295,11 @@ useRegisterPageAIContext({
 |---|---|---|---|
 | `enablePageTools` | `boolean` | `false` | Activate page tool support |
 | `clientToolSchemas` | `Record<string, Tool>` | — | Custom tool schemas for non-BTST pages |
-| `hooks.onBeforeToolsActivated` | `(toolNames, routeName, context) => string[]` | — | Apply a final domain/safety filter after typed tool authorization |
+| `hooks.onBeforeActivateTools` | `(toolNames, routeName, context) => string[]` | — | Apply a final domain/safety filter after typed tool authorization |
 
 ### Tool Authorization Hook
 
-`onBeforeToolsActivated` runs server-side after the structural `routeName` allowlist and the exact `aiChat.tool.activate` rule have succeeded. Use the typed rule for identity, role, subscription, or ownership policy. Use this hook only for exceptional server-side domain/safety narrowing.
+`onBeforeActivateTools` runs server-side after the structural `routeName` allowlist and the exact `aiChat.tool.activate` rule have succeeded. Use the typed rule for identity, role, subscription, or ownership policy. Use this hook only for exceptional server-side domain/safety narrowing.
 
 ```ts title="lib/stack.ts"
 import type { AiChatBackendHooks } from "@btst/stack/plugins/ai-chat/api"
@@ -1307,7 +1307,7 @@ import type { AiChatBackendHooks } from "@btst/stack/plugins/ai-chat/api"
 aiChatBackendPlugin({
   enablePageTools: true,
   hooks: {
-    onBeforeToolsActivated: async (toolNames, routeName, context) => {
+    onBeforeActivateTools: async (toolNames, routeName, context) => {
       const disabled = await loadEmergencyToolDisableList()
       return toolNames.filter((name) => !disabled.has(name))
     },

--- a/e2e/tests/smoke.page-context.spec.ts
+++ b/e2e/tests/smoke.page-context.spec.ts
@@ -237,11 +237,11 @@ test.describe("Page AI Context — structural (no OpenAI key needed)", () => {
 		expect(capturedBody!.routeName).toBe("blog-new-post");
 	});
 
-	test("onBeforeToolsActivated hook denies tools and returns 403", async ({
+	test("onBeforeActivateTools hook denies tools and returns 403", async ({
 		request,
 	}) => {
 		// POST directly to the chat API with the test sentinel header.
-		// The example app's onBeforeToolsActivated hook throws when it sees
+		// The example app's onBeforeActivateTools hook throws when it sees
 		// x-btst-deny-tools: "1", which the endpoint catches and maps to 403.
 		const response = await request.post("/api/data/chat", {
 			headers: {

--- a/packages/stack/src/__tests__/ai-chat-lifecycle-migrations.typecheck.ts
+++ b/packages/stack/src/__tests__/ai-chat-lifecycle-migrations.typecheck.ts
@@ -1,0 +1,61 @@
+import type { AiChatBackendHooks } from "../plugins/ai-chat/api";
+
+const canonicalHooks = {
+	onBeforeChat: async () => undefined,
+	onAfterChat: async () => undefined,
+	onBeforeActivateTools: async () => [],
+	onBeforeListConversations: async () => undefined,
+	onAfterListConversations: async () => undefined,
+	onErrorListConversations: async () => undefined,
+	onBeforeGetConversation: async () => undefined,
+	onAfterGetConversation: async () => undefined,
+	onErrorGetConversation: async () => undefined,
+	onBeforeCreateConversation: async () => undefined,
+	onAfterCreateConversation: async () => undefined,
+	onErrorCreateConversation: async () => undefined,
+	onBeforeUpdateConversation: async () => undefined,
+	onAfterUpdateConversation: async () => undefined,
+	onErrorUpdateConversation: async () => undefined,
+	onBeforeDeleteConversation: async () => undefined,
+	onAfterDeleteConversation: async () => undefined,
+	onErrorDeleteConversation: async () => undefined,
+	onErrorChat: async () => undefined,
+} satisfies AiChatBackendHooks;
+
+void canonicalHooks;
+
+// Explicit migration fixtures: every removed spelling must stay rejected.
+// @ts-expect-error Use onBeforeActivateTools.
+({ onBeforeToolsActivated: async () => [] }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onAfterListConversations.
+({ onConversationsRead: async () => undefined }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onAfterGetConversation.
+({ onConversationRead: async () => undefined }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onAfterCreateConversation.
+({ onConversationCreated: async () => undefined }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onAfterUpdateConversation.
+({ onConversationUpdated: async () => undefined }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onAfterDeleteConversation.
+({ onConversationDeleted: async () => undefined }) satisfies AiChatBackendHooks;
+// @ts-expect-error Use onErrorChat.
+({ onChatError: async () => undefined }) satisfies AiChatBackendHooks;
+({
+	// @ts-expect-error Use onErrorListConversations.
+	onListConversationsError: async () => undefined,
+}) satisfies AiChatBackendHooks;
+({
+	// @ts-expect-error Use onErrorGetConversation.
+	onGetConversationError: async () => undefined,
+}) satisfies AiChatBackendHooks;
+({
+	// @ts-expect-error Use onErrorCreateConversation.
+	onCreateConversationError: async () => undefined,
+}) satisfies AiChatBackendHooks;
+({
+	// @ts-expect-error Use onErrorUpdateConversation.
+	onUpdateConversationError: async () => undefined,
+}) satisfies AiChatBackendHooks;
+({
+	// @ts-expect-error Use onErrorDeleteConversation.
+	onDeleteConversationError: async () => undefined,
+}) satisfies AiChatBackendHooks;

--- a/packages/stack/src/plugins/ai-chat/__tests__/authorization.test.ts
+++ b/packages/stack/src/plugins/ai-chat/__tests__/authorization.test.ts
@@ -7,6 +7,7 @@ import { defineAuthorization } from "../../../authorization";
 import { createServerAuth } from "../../../authorization/server";
 import {
 	aiChatBackendPlugin,
+	AI_CHAT_LIFECYCLE_HOOK_MIGRATIONS,
 	AI_CHAT_OPERATION_INVENTORY,
 	AI_CHAT_RAW_ESCAPE_HATCH_INVENTORY,
 } from "../api";
@@ -106,6 +107,7 @@ function backend(options?: {
 	authorization?: typeof fullAuthorization;
 	adapter?: (db: DatabaseDefinition) => DBAdapter;
 	hooks?: Parameters<typeof aiChatBackendPlugin>[0]["hooks"];
+	enablePageTools?: boolean;
 	tools?: Parameters<typeof aiChatBackendPlugin>[0]["tools"];
 	getIdentity?: (
 		request: Request,
@@ -117,6 +119,7 @@ function backend(options?: {
 			aiChat: aiChatBackendPlugin({
 				model,
 				access: options?.access ?? "authorized",
+				enablePageTools: options?.enablePageTools,
 				hooks: options?.hooks,
 				tools: options?.tools,
 			}),
@@ -199,6 +202,21 @@ describe("AI Chat operation authorization", () => {
 		expect(AI_CHAT_RAW_ESCAPE_HATCH_INVENTORY).toEqual([
 			"api.aiChat.getAllConversations",
 			"api.aiChat.getConversationById",
+		]);
+		expect(Object.keys(AI_CHAT_LIFECYCLE_HOOK_MIGRATIONS)).toHaveLength(12);
+		expect(Object.values(AI_CHAT_LIFECYCLE_HOOK_MIGRATIONS)).toEqual([
+			"onBeforeActivateTools",
+			"onAfterListConversations",
+			"onAfterGetConversation",
+			"onAfterCreateConversation",
+			"onAfterUpdateConversation",
+			"onAfterDeleteConversation",
+			"onErrorChat",
+			"onErrorListConversations",
+			"onErrorGetConversation",
+			"onErrorCreateConversation",
+			"onErrorUpdateConversation",
+			"onErrorDeleteConversation",
 		]);
 		expect(operations?.startStream.resultMode).toBe("passthrough");
 		expect(operations?.listConversations.resultMode).toBe("immutable");
@@ -385,6 +403,323 @@ describe("AI Chat operation authorization", () => {
 		expect(Object.isFrozen(result)).toBe(true);
 	});
 
+	it.each(["http", "request", "internal"] as const)(
+		"invokes every renamed history result phase through %s execution",
+		async (transport) => {
+			const phases: string[] = [];
+			const app = backend({
+				hooks: {
+					onAfterListConversations: () => {
+						phases.push("list");
+					},
+					onAfterGetConversation: () => {
+						phases.push("get");
+					},
+					onAfterCreateConversation: () => {
+						phases.push("create");
+					},
+					onAfterUpdateConversation: () => {
+						phases.push("update");
+					},
+					onAfterDeleteConversation: () => {
+						phases.push("delete");
+					},
+				},
+			});
+			const target = await seedConversation(app);
+
+			if (transport === "http") {
+				const responses = [
+					await app.handler(
+						request("/chat/conversations", { identity: owner }),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, { identity: owner }),
+					),
+					await app.handler(
+						request("/chat/conversations", {
+							method: "POST",
+							identity: owner,
+							body: { title: "Created" },
+						}),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, {
+							method: "PUT",
+							identity: owner,
+							body: { title: "Updated" },
+						}),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, {
+							method: "DELETE",
+							identity: owner,
+						}),
+					),
+				];
+				expect(responses.map((response) => response.status)).toEqual([
+					200, 200, 200, 200, 200,
+				]);
+			} else if (transport === "request") {
+				const api = app.forRequest(request("/lifecycle", { identity: owner }))
+					.api.aiChat;
+				await api.listConversations({});
+				await api.getConversation({ id: target.id });
+				await api.createConversation({ title: "Created" });
+				await api.updateConversation({
+					id: target.id,
+					data: { title: "Updated" },
+				});
+				await api.deleteConversation({ id: target.id });
+			} else {
+				await app.internal.aiChat.listConversations({});
+				await app.internal.aiChat.getConversation({ id: target.id });
+				await app.internal.aiChat.createConversation({ title: "Created" });
+				await app.internal.aiChat.updateConversation({
+					id: target.id,
+					data: { title: "Updated" },
+				});
+				await app.internal.aiChat.deleteConversation({ id: target.id });
+			}
+
+			expect(phases).toEqual(["list", "get", "create", "update", "delete"]);
+		},
+	);
+
+	it.each(["http", "request", "internal"] as const)(
+		"invokes every renamed history error phase through %s execution",
+		async (transport) => {
+			const phases: string[] = [];
+			const fail = (phase: string) => () => {
+				phases.push(`before:${phase}`);
+				throw new Error(`${phase} rejected`);
+			};
+			const observe = (phase: string) => (error: Error) => {
+				phases.push(`error:${phase}:${error.message}`);
+			};
+			const app = backend({
+				hooks: {
+					onBeforeListConversations: fail("list"),
+					onErrorListConversations: observe("list"),
+					onBeforeGetConversation: fail("get"),
+					onErrorGetConversation: observe("get"),
+					onBeforeCreateConversation: fail("create"),
+					onErrorCreateConversation: observe("create"),
+					onBeforeUpdateConversation: fail("update"),
+					onErrorUpdateConversation: observe("update"),
+					onBeforeDeleteConversation: fail("delete"),
+					onErrorDeleteConversation: observe("delete"),
+				},
+			});
+			const target = await seedConversation(app);
+
+			if (transport === "http") {
+				const responses = [
+					await app.handler(
+						request("/chat/conversations", { identity: owner }),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, { identity: owner }),
+					),
+					await app.handler(
+						request("/chat/conversations", {
+							method: "POST",
+							identity: owner,
+							body: { title: "Rejected" },
+						}),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, {
+							method: "PUT",
+							identity: owner,
+							body: { title: "Rejected" },
+						}),
+					),
+					await app.handler(
+						request(`/chat/conversations/${target.id}`, {
+							method: "DELETE",
+							identity: owner,
+						}),
+					),
+				];
+				expect(responses.map((response) => response.status)).toEqual([
+					403, 403, 403, 403, 403,
+				]);
+			} else {
+				const api =
+					transport === "request"
+						? app.forRequest(request("/lifecycle", { identity: owner })).api
+								.aiChat
+						: app.internal.aiChat;
+				for (const operation of [
+					() => api.listConversations({}),
+					() => api.getConversation({ id: target.id }),
+					() => api.createConversation({ title: "Rejected" }),
+					() =>
+						api.updateConversation({
+							id: target.id,
+							data: { title: "Rejected" },
+						}),
+					() => api.deleteConversation({ id: target.id }),
+				]) {
+					await expect(operation()).rejects.toMatchObject({ statusCode: 403 });
+				}
+			}
+
+			expect(phases).toEqual([
+				"before:list",
+				"error:list:list rejected",
+				"before:get",
+				"error:get:get rejected",
+				"before:create",
+				"error:create:create rejected",
+				"before:update",
+				"error:update:update rejected",
+				"before:delete",
+				"error:delete:delete rejected",
+			]);
+		},
+	);
+
+	it.each(["http", "request", "internal"] as const)(
+		"keeps explicit tool activation filtering on %s execution",
+		async (transport) => {
+			const activated = vi.fn(() => [] as const);
+			const app = backend({
+				enablePageTools: true,
+				hooks: { onBeforeActivateTools: activated },
+			});
+			const conversation = await seedConversation(app);
+			const input = {
+				...messageBody,
+				conversationId: conversation.id,
+				availableTools: ["fillBlogForm"],
+				routeName: "newPost",
+			};
+
+			if (transport === "http") {
+				const response = await app.handler(
+					request("/chat", {
+						method: "POST",
+						identity: owner,
+						body: input,
+					}),
+				);
+				expect(response.status).toBe(200);
+			} else if (transport === "request") {
+				await expect(
+					app
+						.forRequest(request("/chat", { identity: owner }))
+						.api.aiChat.startStream(input),
+				).resolves.toBeInstanceOf(Response);
+			} else {
+				await expect(
+					app.internal.aiChat.startStream({
+						...input,
+						trustedUserId: owner.id,
+					}),
+				).resolves.toBeInstanceOf(Response);
+			}
+
+			expect(activated).toHaveBeenCalledWith(
+				["fillBlogForm"],
+				"newPost",
+				expect.any(Object),
+			);
+			expect(streamText).toHaveBeenLastCalledWith(
+				expect.not.objectContaining({ tools: expect.anything() }),
+			);
+		},
+	);
+
+	it("preserves validation, fact, authorization, lifecycle, and domain ordering", async () => {
+		const events: string[] = [];
+		let rejectBefore = false;
+		const orderedAuthorization = defineAuthorization({
+			identity: z.object({ id: z.string(), role: z.enum(["user", "admin"]) }),
+			permissions: [aiChatPermissions] as const,
+			rules: ({ aiChat }) => [
+				aiChat.conversation.update.when(({ facts }) => {
+					events.push(`authorize:${facts.exists}`);
+					return true;
+				}),
+			],
+		});
+		const app = backend({
+			authorization: orderedAuthorization as typeof fullAuthorization,
+			hooks: {
+				onBeforeUpdateConversation: (_id, _data, context) => {
+					events.push(`before:${context.facts.exists}`);
+					if (rejectBefore) throw new Error("before rejected");
+				},
+				onAfterUpdateConversation: (conversation) => {
+					events.push(`after:${conversation.title}`);
+				},
+				onErrorUpdateConversation: (error) => {
+					events.push(`error:${error.message}`);
+				},
+			},
+		});
+		const conversation = await seedConversation(app);
+
+		await expect(
+			app
+				.forRequest(request("/invalid", { identity: owner }))
+				.api.aiChat.updateConversation({
+					id: conversation.id,
+					data: { title: "" },
+				}),
+		).rejects.toBeDefined();
+		expect(events).toEqual([]);
+
+		await app
+			.forRequest(request("/valid", { identity: owner }))
+			.api.aiChat.updateConversation({
+				id: conversation.id,
+				data: { title: "Request update" },
+			});
+		expect(events).toEqual([
+			"authorize:true",
+			"before:true",
+			"after:Request update",
+		]);
+		await expect(
+			app.adapter.findOne<Conversation>({
+				model: "conversation",
+				where: [{ field: "id", value: conversation.id }],
+			}),
+		).resolves.toMatchObject({ title: "Request update" });
+
+		events.length = 0;
+		await app.internal.aiChat.updateConversation({
+			id: conversation.id,
+			data: { title: "Trusted update" },
+		});
+		expect(events).toEqual(["before:true", "after:Trusted update"]);
+		await expect(
+			app.adapter.findOne<Conversation>({
+				model: "conversation",
+				where: [{ field: "id", value: conversation.id }],
+			}),
+		).resolves.toMatchObject({ title: "Trusted update" });
+
+		events.length = 0;
+		rejectBefore = true;
+		await expect(
+			app
+				.forRequest(request("/rejected", { identity: owner }))
+				.api.aiChat.updateConversation({
+					id: conversation.id,
+					data: { title: "Rejected update" },
+				}),
+		).rejects.toMatchObject({ statusCode: 403, message: "before rejected" });
+		expect(events).toEqual([
+			"authorize:true",
+			"before:true",
+			"error:before rejected",
+		]);
+	});
+
 	it("keeps collection scoping server-only and partitions owner histories", async () => {
 		const app = backend();
 		await seedConversation(app, owner.id, "Owner");
@@ -469,10 +804,10 @@ describe("AI Chat operation authorization", () => {
 
 	it("fails closed before completion writes if transaction isolation disappears", async () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
-		const onChatError = vi.fn();
+		const onErrorChat = vi.fn();
 		const app = backend({
 			adapter: databaseLikeMemory,
-			hooks: { onChatError },
+			hooks: { onErrorChat },
 		});
 		await app
 			.forRequest(request("/chat", { identity: owner }))
@@ -501,7 +836,7 @@ describe("AI Chat operation authorization", () => {
 				where: [{ field: "role", value: "assistant", operator: "eq" }],
 			}),
 		).toBe(0);
-		expect(onChatError).toHaveBeenCalledWith(
+		expect(onErrorChat).toHaveBeenCalledWith(
 			expect.objectContaining({ code: "ATOMIC_TRANSACTION_REQUIRED" }),
 			expect.any(Object),
 		);
@@ -902,7 +1237,7 @@ describe("AI Chat operation authorization", () => {
 		const onError = vi.fn();
 		const app = backend({
 			getIdentity,
-			hooks: { onBeforeChat: before, onChatError: onError },
+			hooks: { onBeforeChat: before, onErrorChat: onError },
 		});
 
 		await expect(
@@ -1095,8 +1430,8 @@ describe("AI Chat operation authorization", () => {
 	});
 
 	it("reports asynchronous provider failures for every stream transport", async () => {
-		const onChatError = vi.fn();
-		const app = backend({ hooks: { onChatError } });
+		const onErrorChat = vi.fn();
+		const app = backend({ hooks: { onErrorChat } });
 		await app.handler(
 			request("/chat", { method: "POST", identity: owner, body: messageBody }),
 		);
@@ -1113,8 +1448,8 @@ describe("AI Chat operation authorization", () => {
 		>) {
 			await options.onError({ error: new Error("provider failed") });
 		}
-		expect(onChatError).toHaveBeenCalledTimes(3);
-		for (const [error] of onChatError.mock.calls) {
+		expect(onErrorChat).toHaveBeenCalledTimes(3);
+		for (const [error] of onErrorChat.mock.calls) {
 			expect(error).toMatchObject({ message: "provider failed" });
 		}
 	});
@@ -1125,7 +1460,7 @@ describe("AI Chat operation authorization", () => {
 		const before = vi.fn();
 		const onError = vi.fn();
 		app = backend({
-			hooks: { onBeforeChat: before, onChatError: onError },
+			hooks: { onBeforeChat: before, onErrorChat: onError },
 			getIdentity: async () => {
 				if (conversation) {
 					await app.adapter.update({
@@ -1494,7 +1829,7 @@ describe("AI Chat operation authorization", () => {
 		app = backend({
 			hooks: {
 				onBeforeChat: before,
-				onConversationCreated: afterCreate,
+				onAfterCreateConversation: afterCreate,
 			},
 		});
 		const conversation = await seedConversation(app);
@@ -1612,8 +1947,8 @@ describe("AI Chat operation authorization", () => {
 
 	it("does not persist a stale completion after a newer stream claim", async () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
-		const onChatError = vi.fn();
-		const app = backend({ hooks: { onChatError } });
+		const onErrorChat = vi.fn();
+		const app = backend({ hooks: { onErrorChat } });
 		const conversation = await seedConversation(app);
 		const input = { ...messageBody, conversationId: conversation.id };
 
@@ -1640,7 +1975,7 @@ describe("AI Chat operation authorization", () => {
 				where: [{ field: "role", value: "assistant", operator: "eq" }],
 			}),
 		).toBe(0);
-		expect(onChatError).toHaveBeenCalledOnce();
+		expect(onErrorChat).toHaveBeenCalledOnce();
 
 		await secondFinish?.({ text: "current answer" });
 		const assistants = await app.adapter.findMany<Message>({

--- a/packages/stack/src/plugins/ai-chat/api/lifecycle-migrations.ts
+++ b/packages/stack/src/plugins/ai-chat/api/lifecycle-migrations.ts
@@ -1,0 +1,20 @@
+/**
+ * Removed AI Chat lifecycle names and their canonical v3 replacements.
+ *
+ * This structured inventory is the source for migration documentation and
+ * repository guards. Names absent from this map did not change.
+ */
+export const AI_CHAT_LIFECYCLE_HOOK_MIGRATIONS = Object.freeze({
+	onBeforeToolsActivated: "onBeforeActivateTools",
+	onConversationsRead: "onAfterListConversations",
+	onConversationRead: "onAfterGetConversation",
+	onConversationCreated: "onAfterCreateConversation",
+	onConversationUpdated: "onAfterUpdateConversation",
+	onConversationDeleted: "onAfterDeleteConversation",
+	onChatError: "onErrorChat",
+	onListConversationsError: "onErrorListConversations",
+	onGetConversationError: "onErrorGetConversation",
+	onCreateConversationError: "onErrorCreateConversation",
+	onUpdateConversationError: "onErrorUpdateConversation",
+	onDeleteConversationError: "onErrorDeleteConversation",
+} as const);

--- a/packages/stack/src/plugins/ai-chat/api/operations.ts
+++ b/packages/stack/src/plugins/ai-chat/api/operations.ts
@@ -299,7 +299,7 @@ export interface AiChatBackendHooks {
 	 * Post-authorization tool safety/filter hook. Structural route validation and
 	 * exact `tool.activate` authorization have already succeeded.
 	 */
-	onBeforeToolsActivated?: (
+	onBeforeActivateTools?: (
 		toolNames: readonly string[],
 		routeName: string | undefined,
 		context: ChatApiContext<
@@ -315,77 +315,77 @@ export interface AiChatBackendHooks {
 			StreamStartFacts
 		>,
 	) => Promise<void> | void;
-	onConversationsRead?: (
+	onAfterListConversations?: (
 		conversations: readonly SerializedConversation[],
 		context: ChatApiContext<
 			z.output<typeof EmptyInputSchema>,
 			ConversationReadFacts
 		>,
 	) => Promise<void> | void;
-	onConversationRead?: (
+	onAfterGetConversation?: (
 		conversation: DeepReadonly<AiChatConversationResult>,
 		context: ChatApiContext<
 			z.output<typeof ConversationOperationInputSchema>,
 			ConversationReadFacts
 		>,
 	) => Promise<void> | void;
-	onConversationCreated?: (
+	onAfterCreateConversation?: (
 		conversation: DeepReadonly<SerializedConversation>,
 		context: ChatApiContext<
 			z.output<typeof createConversationSchema>,
 			undefined
 		>,
 	) => Promise<void> | void;
-	onConversationUpdated?: (
+	onAfterUpdateConversation?: (
 		conversation: DeepReadonly<SerializedConversation>,
 		context: ChatApiContext<
 			z.output<typeof UpdateConversationOperationInputSchema>,
 			ConversationRecordFacts
 		>,
 	) => Promise<void> | void;
-	onConversationDeleted?: (
+	onAfterDeleteConversation?: (
 		conversationId: string,
 		context: ChatApiContext<
 			z.output<typeof ConversationOperationInputSchema>,
 			ConversationRecordFacts
 		>,
 	) => Promise<void> | void;
-	onChatError?: (
+	onErrorChat?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof ChatOperationInputSchema>,
 			StreamStartFacts
 		>,
 	) => Promise<void> | void;
-	onListConversationsError?: (
+	onErrorListConversations?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof EmptyInputSchema>,
 			ConversationReadFacts
 		>,
 	) => Promise<void> | void;
-	onGetConversationError?: (
+	onErrorGetConversation?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof ConversationOperationInputSchema>,
 			ConversationReadFacts
 		>,
 	) => Promise<void> | void;
-	onCreateConversationError?: (
+	onErrorCreateConversation?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof createConversationSchema>,
 			undefined
 		>,
 	) => Promise<void> | void;
-	onUpdateConversationError?: (
+	onErrorUpdateConversation?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof UpdateConversationOperationInputSchema>,
 			ConversationRecordFacts
 		>,
 	) => Promise<void> | void;
-	onDeleteConversationError?: (
+	onErrorDeleteConversation?: (
 		error: Error,
 		context: ChatApiContext<
 			z.output<typeof ConversationOperationInputSchema>,
@@ -977,14 +977,14 @@ export function createAiChatOperations(
 					? allConversations.filter((conversation) => !conversation.userId)
 					: allConversations
 			).map(publicConversation);
-			await hooks?.onConversationsRead?.(
+			await hooks?.onAfterListConversations?.(
 				conversations,
 				hookContext(context, { query: context.input }),
 			);
 			return conversations;
 		},
 		onError: ({ error, ...context }) =>
-			notifyError(hooks?.onListConversationsError, error, context, {
+			notifyError(hooks?.onErrorListConversations, error, context, {
 				query: context.input,
 			}),
 	});
@@ -1053,14 +1053,14 @@ export function createAiChatOperations(
 				);
 			}
 			const result = conversationResult(conversation);
-			await hooks?.onConversationRead?.(
+			await hooks?.onAfterGetConversation?.(
 				result,
 				hookContext(context, { params: { id: context.input.id } }),
 			);
 			return result;
 		},
 		onError: ({ error, ...context }) =>
-			notifyError(hooks?.onGetConversationError, error, context, {
+			notifyError(hooks?.onErrorGetConversation, error, context, {
 				params: { id: context.input.id },
 			}),
 	});
@@ -1099,7 +1099,7 @@ export function createAiChatOperations(
 				} as Conversation,
 			});
 			const result = publicConversation(conversation);
-			await hooks?.onConversationCreated?.(
+			await hooks?.onAfterCreateConversation?.(
 				result,
 				hookContext(context, { body: context.input }),
 			);
@@ -1107,7 +1107,7 @@ export function createAiChatOperations(
 		},
 		onError: ({ error, ...context }) => {
 			markMemoryRollback(adapter, error);
-			return notifyError(hooks?.onCreateConversationError, error, context, {
+			return notifyError(hooks?.onErrorCreateConversation, error, context, {
 				body: context.input,
 			});
 		},
@@ -1209,7 +1209,7 @@ export function createAiChatOperations(
 			}
 		},
 		after: (context) =>
-			hooks?.onConversationUpdated?.(
+			hooks?.onAfterUpdateConversation?.(
 				context.result,
 				hookContext(context, {
 					body: context.input,
@@ -1218,7 +1218,7 @@ export function createAiChatOperations(
 			),
 		onError: ({ error, ...context }) => {
 			markMemoryRollback(adapter, error);
-			return notifyError(hooks?.onUpdateConversationError, error, context, {
+			return notifyError(hooks?.onErrorUpdateConversation, error, context, {
 				body: context.input,
 				params: { id: context.input.id },
 			});
@@ -1306,13 +1306,13 @@ export function createAiChatOperations(
 			}
 		},
 		after: (context) =>
-			hooks?.onConversationDeleted?.(
+			hooks?.onAfterDeleteConversation?.(
 				context.input.id,
 				hookContext(context, { params: { id: context.input.id } }),
 			),
 		onError: ({ error, ...context }) => {
 			markMemoryRollback(adapter, error);
-			return notifyError(hooks?.onDeleteConversationError, error, context, {
+			return notifyError(hooks?.onErrorDeleteConversation, error, context, {
 				params: { id: context.input.id },
 			});
 		},
@@ -1536,11 +1536,11 @@ export function createAiChatOperations(
 				);
 
 				let allowedToolNames = [...prepared.toolNames];
-				if (allowedToolNames.length > 0 && hooks?.onBeforeToolsActivated) {
-					const onBeforeToolsActivated = hooks.onBeforeToolsActivated;
+				if (allowedToolNames.length > 0 && hooks?.onBeforeActivateTools) {
+					const onBeforeActivateTools = hooks.onBeforeActivateTools;
 					const filtered = await runBeforeHook(
 						() =>
-							onBeforeToolsActivated(
+							onBeforeActivateTools(
 								allowedToolNames,
 								context.input.routeName,
 								contextForHooks,
@@ -1559,12 +1559,12 @@ export function createAiChatOperations(
 
 			const reportStreamError = async (error: unknown) => {
 				try {
-					await hooks?.onChatError?.(
+					await hooks?.onErrorChat?.(
 						normalizeError(error, "Chat provider stream failed"),
 						contextForHooks,
 					);
 				} catch (hookError) {
-					console.error("[ai-chat] Error in onChatError hook:", hookError);
+					console.error("[ai-chat] Error in onErrorChat hook:", hookError);
 				}
 			};
 
@@ -1817,13 +1817,13 @@ export function createAiChatOperations(
 						} catch (error) {
 							console.error("[ai-chat] Error in stream completion:", error);
 							try {
-								await hooks?.onChatError?.(
+								await hooks?.onErrorChat?.(
 									normalizeError(error, "Chat completion persistence failed"),
 									contextForHooks,
 								);
 							} catch (hookError) {
 								console.error(
-									"[ai-chat] Error in onChatError hook:",
+									"[ai-chat] Error in onErrorChat hook:",
 									hookError,
 								);
 							}
@@ -1848,7 +1848,7 @@ export function createAiChatOperations(
 		},
 		onError: ({ error, ...context }) => {
 			markMemoryRollback(adapter, error);
-			return notifyError(hooks?.onChatError, error, context, {
+			return notifyError(hooks?.onErrorChat, error, context, {
 				body: context.input,
 			});
 		},

--- a/packages/stack/src/plugins/ai-chat/api/plugin.ts
+++ b/packages/stack/src/plugins/ai-chat/api/plugin.ts
@@ -28,6 +28,7 @@ export {
 	ConversationOperationInputSchema,
 	UpdateConversationOperationInputSchema,
 } from "./operations";
+export { AI_CHAT_LIFECYCLE_HOOK_MIGRATIONS } from "./lifecycle-migrations";
 
 type KnownKeys<T> = {
 	[K in keyof T]: string extends K ? never : K;

--- a/scripts/codegen/files/nextjs/lib/stack.ts
+++ b/scripts/codegen/files/nextjs/lib/stack.ts
@@ -250,7 +250,7 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 				},
 				enablePageTools: true,
 				hooks: {
-					onConversationCreated: async (conversation) => {
+					onAfterCreateConversation: async (conversation) => {
 						console.log(
 							"Conversation created:",
 							conversation.id,
@@ -265,7 +265,7 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 							messages.length,
 						);
 					},
-					onBeforeToolsActivated: async (toolNames, routeName, context) => {
+					onBeforeActivateTools: async (toolNames, routeName, context) => {
 						if (context.headers?.get?.("x-btst-deny-tools") === "1") {
 							throw new AiChatOperationError(
 								403,

--- a/scripts/codegen/files/react-router/app/lib/stack.ts
+++ b/scripts/codegen/files/react-router/app/lib/stack.ts
@@ -246,10 +246,10 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			},
 			enablePageTools: true,
 			hooks: {
-				onConversationCreated: async (conversation) => {
+				onAfterCreateConversation: async (conversation) => {
 					console.log("Conversation created:", conversation.id);
 				},
-				onBeforeToolsActivated: async (toolNames, _routeName, context) => {
+				onBeforeActivateTools: async (toolNames, _routeName, context) => {
 					if (context.headers?.get?.("x-btst-deny-tools") === "1") {
 						throw new AiChatOperationError(
 							403,

--- a/scripts/codegen/files/tanstack/src/lib/stack.ts
+++ b/scripts/codegen/files/tanstack/src/lib/stack.ts
@@ -246,10 +246,10 @@ Keep all responses concise. Do not discuss the technology stack or internal tool
 			},
 			enablePageTools: true,
 			hooks: {
-				onConversationCreated: async (conversation) => {
+				onAfterCreateConversation: async (conversation) => {
 					console.log("Conversation created:", conversation.id);
 				},
-				onBeforeToolsActivated: async (toolNames, _routeName, context) => {
+				onBeforeActivateTools: async (toolNames, _routeName, context) => {
 					if (context.headers?.get?.("x-btst-deny-tools") === "1") {
 						throw new AiChatOperationError(
 							403,


### PR DESCRIPTION
## Summary

- normalize every existing AI Chat lifecycle hook to the canonical action-first `onBefore` / `onAfter` / `onError` grammar without adding phases or changing timing
- preserve domain-specific chat completion and explicit tool activation behavior, including tool filtering and stream error reporting
- export a complete structured old-to-new lifecycle mapping and reject every removed spelling in compile-time migration fixtures
- update AI Chat docs, generated framework sources, and the page-context E2E reference
- cover renamed phases through HTTP, request-authorized, and trusted internal execution, including validation/auth/lifecycle ordering and error propagation

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm knip`
- `pnpm --filter @btst/stack test -- --run` (72 files, 915 tests)
- `pnpm --filter @btst/stack exec vitest run src/plugins/media/__tests__/identity-partition.test.tsx` (isolated rerun of one transient full-suite timeout)
- `pnpm build` in `docs/`
- `pnpm --filter @btst/stack build-registry` (clean generated artifacts)

Closes #218
