### PR TITLE
chore: prepare v3.0.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ aligned Better DB CLI in isolation, so its dependencies and `btst` binary do
 not enter your application graph:
 
 ```bash
-npx @btst/codegen@next generate --orm drizzle --config lib/stack.ts --output db/schema.ts
+npx @btst/codegen@0.2.0 generate --orm drizzle --config lib/stack.ts --output db/schema.ts
 ```
 
 Supports Prisma, Drizzle, MongoDB and Kysely SQL dialects.

--- a/docs/content/docs/breaking-changes.mdx
+++ b/docs/content/docs/breaking-changes.mdx
@@ -26,33 +26,30 @@ paths.
 
 ### 0. Pin the verified cohort and a rollback point
 
-The final stable package versions will be set in a separate release-preparation
-commit before the release job validates and publishes them. Until stable v3 is
-published, use this exact focused RC4 cohort:
+Use this exact stable v3 cohort:
 
 | Role | Exact version |
 | --- | --- |
-| Core | `@btst/stack@3.0.0-rc.4` |
-| Scaffold and command wrapper | `@btst/codegen@0.2.0-rc.4` |
-| Optional Better Auth UI companion | `@btst/better-auth-ui@2.0.0-rc.4` |
+| Core | `@btst/stack@3.0.0` |
+| Scaffold and command wrapper | `@btst/codegen@0.2.0` |
+| Optional Better Auth UI companion | `@btst/better-auth-ui@2.0.0` |
 | Better DB and the selected BTST adapter | `2.2.3` |
-| Database CLI for generation/migration | `@btst/cli@2.2.4`, delegated by Codegen RC4 from the consumer project directory |
+| Database CLI for generation/migration | `@btst/cli@2.2.4`, delegated by Codegen 0.2.0 from the consumer project directory |
 | Better Auth and Core | `better-auth@1.6.16`, `@better-auth/core@1.6.16` |
 | Better Auth utilities and transport | `@better-auth/utils@0.4.1`, `@better-fetch/fetch@1.2.2`, `better-call@1.3.6` |
 | API-key and passkey declarations, when the companion is installed | `@better-auth/api-key@1.6.16`, `@better-auth/passkey@1.6.16` |
 
-When stable v3 is published, replace only the three release-candidate entries
-with their exact published stable versions. Retain the Better Auth `1.6.16`
-and Better DB/adapter `2.2.3` cohorts unless a later migration guide explicitly
-changes them. Do not move this release to Better Auth `1.7.x`, and do not use a
-floating `latest`, `next`, caret, or workspace range in a production migration.
+Retain the Better Auth `1.6.16` and Better DB/adapter `2.2.3` cohorts unless a
+later migration guide explicitly changes them. Do not move this release to
+Better Auth `1.7.x`, and do not use a floating `latest`, `next`, caret, or
+workspace range in a production migration.
 
 For example, a Drizzle application without the optional auth companion can pin
-the current candidate with:
+the stable cohort with:
 
 ```bash
-pnpm add --save-exact @btst/stack@3.0.0-rc.4 @btst/adapter-drizzle@2.2.3
-pnpm add --save-dev --save-exact @btst/codegen@0.2.0-rc.4
+pnpm add --save-exact @btst/stack@3.0.0 @btst/adapter-drizzle@2.2.3
+pnpm add --save-dev --save-exact @btst/codegen@0.2.0
 pnpm install --frozen-lockfile
 ```
 
@@ -392,7 +389,7 @@ that looks correct can still be bound to the wrong endpoint or identity cache.
 ### 7. Regenerate or merge the framework scaffold
 
 `@btst/codegen` owns application scaffolding. The focused
-`@btst/codegen@0.2.0-rc.4` candidate delegates `generate` and `migrate` to
+`@btst/codegen@0.2.0` delegates `generate` and `migrate` to
 `@btst/cli@2.2.4` from the consumer project directory. That behavior loads the
 application's TypeScript/JavaScript aliases and standard Next.js environment
 files, resolves its Prisma or Drizzle adapter and ORM peers, and ignores only a
@@ -402,9 +399,9 @@ Use the scaffold as a reference diff for an existing application rather than
 blindly overwriting owned files:
 
 ```bash
-npx @btst/codegen@0.2.0-rc.4 init --framework=nextjs --adapter=drizzle \
+npx @btst/codegen@0.2.0 init --framework=nextjs --adapter=drizzle \
   --plugins=blog,comments --cwd=. --skip-install
-npx @btst/codegen@0.2.0-rc.4 generate \
+npx @btst/codegen@0.2.0 generate \
   --orm=drizzle --config=lib/stack.ts --output=src/db/schema.ts
 ```
 
@@ -422,26 +419,26 @@ server auth factory. Map the session into `createClientAuth` and
 `createServerAuth` yourself when business plugins should authorize the same
 person. Role and tenant fields remain application-owned.
 
-Auth plus account is the minimal runtime integration. Pin the candidate cohort
+Auth plus account is the minimal runtime integration. Pin the stable cohort
 exactly when it is selected:
 
 ```bash
-pnpm add --save-exact @btst/better-auth-ui@2.0.0-rc.4 \
+pnpm add --save-exact @btst/better-auth-ui@2.0.0 \
   better-auth@1.6.16 @better-auth/core@1.6.16 \
   @better-auth/api-key@1.6.16 @better-auth/passkey@1.6.16 \
   @better-auth/utils@0.4.1 @better-fetch/fetch@1.2.2 better-call@1.3.6
 ```
 
-`@btst/codegen@0.2.0-rc.4` includes the explicit `better-auth-ui` scaffold
+`@btst/codegen@0.2.0` includes the explicit `better-auth-ui` scaffold
 selection and generates the minimal auth-and-account path described in the
 focused guide. It does not generate or replace the application's Better Auth
 backend, database, schema, providers, secrets, or optional runtime plugins.
 
-API-key and passkey are required declaration peers in the RC4 package because
-its complete `AuthClient` type exposes those surfaces. Installing them satisfies
-the strict type/dependency graph; it does not enable either feature. Enable
-organization, API-key, passkey, or multi-session only when the matching Better
-Auth server and browser plugins are configured. Optional `tanstack`,
+API-key and passkey are required declaration peers in the stable package
+because its complete `AuthClient` type exposes those surfaces. Installing them
+satisfies the strict type/dependency graph; it does not enable either feature.
+Enable organization, API-key, passkey, or multi-session only when the matching
+Better Auth server and browser plugins are configured. Optional `tanstack`,
 `instantdb`, and `triplit` companion subpaths have additional peers; the base
 auth/account integration does not require those adapter peers.
 
@@ -498,8 +495,8 @@ repository root before publishing:
 ```bash
 pnpm test:packed-consumers
 BTST_ARTIFACT_DIR="$(mktemp -d)"
-npm pack @btst/better-auth-ui@2.0.0-rc.4 --pack-destination "$BTST_ARTIFACT_DIR"
-BTST_AUTH_UI_TARBALL="$BTST_ARTIFACT_DIR/btst-better-auth-ui-2.0.0-rc.4.tgz"
+npm pack @btst/better-auth-ui@2.0.0 --pack-destination "$BTST_ARTIFACT_DIR"
+BTST_AUTH_UI_TARBALL="$BTST_ARTIFACT_DIR/btst-better-auth-ui-2.0.0.tgz"
 pnpm smoke:packed-consumer -- --fixture core --package-manager npm
 pnpm smoke:packed-consumer -- --fixture core --package-manager pnpm
 pnpm smoke:packed-consumer -- --fixture auth --package-manager npm \

--- a/docs/content/docs/databases/adapters.mdx
+++ b/docs/content/docs/databases/adapters.mdx
@@ -89,7 +89,7 @@ The memory adapter remains useful for local, single-process development where
 the plugin documents serialized access. It is not a production isolation
 substitute. The generated scaffold rejects Form Builder with memory or MongoDB
 and Media with MongoDB; use Prisma, Drizzle, or Kysely for those production
-configurations. `@btst/codegen@0.2.0-rc.4 init` adds `transaction: true`
+configurations. `@btst/codegen@0.2.0 init` adds `transaction: true`
 automatically for all four atomic-write plugins: AI Chat, Form Builder, Kanban,
 and Media.
 

--- a/docs/content/docs/plugins/better-auth-ui.mdx
+++ b/docs/content/docs/plugins/better-auth-ui.mdx
@@ -41,7 +41,8 @@ are not enabled by the generated code. Add one only after the matching Better
 Auth server and client plugin are configured in your application.
 
 <Callout type="info">
-  RC4 publishes API-key and passkey as required declaration peers because its
+  The stable package publishes API-key and passkey as required declaration
+  peers because its
   synthetic full `AuthClient` type exposes their surfaces. The CLI therefore
   installs their aligned 1.6.16 packages to keep strict dependency trees clean,
   but it does not import, register, or enable either runtime feature. Activation
@@ -51,7 +52,7 @@ Auth server and client plugin are configured in your application.
 
 ## Supported release cohort
 
-The corrected companion candidate is `@btst/better-auth-ui@2.0.0-rc.4`. Its
+The stable companion release is `@btst/better-auth-ui@2.0.0`. Its
 stable-v3 compatibility contract retains these exact versions:
 
 | Package | Version |
@@ -71,7 +72,7 @@ For a manual installation, add the companion and exact auth cohort alongside
 your existing BTST dependencies:
 
 ```bash
-pnpm add @btst/better-auth-ui@2.0.0-rc.4 \
+pnpm add @btst/better-auth-ui@2.0.0 \
   better-auth@1.6.16 @better-auth/core@1.6.16 \
   @better-auth/api-key@1.6.16 @better-auth/passkey@1.6.16 \
   @better-auth/utils@0.4.1 @better-fetch/fetch@1.2.2 better-call@1.3.6

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/codegen",
-  "version": "0.2.0-rc.4",
+  "version": "0.2.0",
   "description": "BTST project scaffolding and CLI passthrough commands.",
   "repository": {
     "type": "git",

--- a/packages/cli/scripts/test-better-auth-ui-fixtures.mjs
+++ b/packages/cli/scripts/test-better-auth-ui-fixtures.mjs
@@ -19,7 +19,7 @@ const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
 const CLI_DIRECTORY = resolve(SCRIPT_DIRECTORY, "..");
 const REPOSITORY_ROOT = resolve(CLI_DIRECTORY, "../..");
 const SHADCN_VERSION = "4.0.5";
-const BETTER_AUTH_UI_VERSION = "2.0.0-rc.4";
+const BETTER_AUTH_UI_VERSION = "2.0.0";
 const FRAMEWORKS = ["nextjs", "react-router", "tanstack"];
 
 const AUTH_COHORT = Object.freeze({

--- a/packages/cli/src/utils/__tests__/package-installer.test.ts
+++ b/packages/cli/src/utils/__tests__/package-installer.test.ts
@@ -21,9 +21,10 @@ describe("installInitDependencies", () => {
 		});
 
 		const installArguments = execa.mock.calls[0]?.[1] as string[];
+		expect(installArguments).toContain("@btst/stack@3.0.0");
 		expect(installArguments).toContain("@btst/adapter-drizzle@2.2.3");
 		expect(installArguments).toContain("drizzle-orm@0.45.2");
-		expect(installArguments).toContain("@btst/better-auth-ui@2.0.0-rc.4");
+		expect(installArguments).toContain("@btst/better-auth-ui@2.0.0");
 		expect(installArguments).toContain("better-auth@1.6.16");
 		expect(installArguments).toContain("@better-auth/core@1.6.16");
 		expect(installArguments).toContain("@better-auth/utils@0.4.1");

--- a/packages/cli/src/utils/__tests__/scaffold-plan.test.ts
+++ b/packages/cli/src/utils/__tests__/scaffold-plan.test.ts
@@ -1051,7 +1051,7 @@ describe("scaffold plan", () => {
 			expect(provider?.content).not.toContain("passkey:");
 			expect(plan.cssImports).toContain("@btst/better-auth-ui/css");
 			expect(plan.extraPackageVersions).toMatchObject({
-				"@btst/better-auth-ui": "2.0.0-rc.4",
+				"@btst/better-auth-ui": "2.0.0",
 				"better-auth": "1.6.16",
 			});
 		},

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -186,14 +186,14 @@ export const PLUGINS: readonly PluginMeta[] = [
 			"@better-auth/utils",
 			"@better-fetch/fetch",
 			"better-call",
-			// RC4 exposes API-key/passkey types from its synthetic full AuthClient,
+			// Stable 2.0.0 exposes API-key/passkey types from its synthetic full AuthClient,
 			// so these remain required declaration peers even when their runtime
 			// features are not configured by the generated auth+account scaffold.
 			"@better-auth/api-key",
 			"@better-auth/passkey",
 		],
 		extraInstallSpecs: [
-			"@btst/better-auth-ui@2.0.0-rc.4",
+			"@btst/better-auth-ui@2.0.0",
 			"better-auth@1.6.16",
 			"@better-auth/core@1.6.16",
 			"@better-auth/utils@0.4.1",

--- a/packages/cli/src/utils/package-installer.ts
+++ b/packages/cli/src/utils/package-installer.ts
@@ -44,7 +44,7 @@ export async function installInitDependencies(input: {
 	});
 
 	const packages = [
-		"@btst/stack@next",
+		"@btst/stack@3.0.0",
 		"@btst/yar@1.3.2",
 		"@tanstack/react-query@5.100.14",
 		adapterMeta.installSpec ?? adapterMeta.packageName,

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btst/stack",
-  "version": "3.0.0-rc.4",
+  "version": "3.0.0",
   "description": "A composable, plugin-based library for building full-stack applications.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- promote `@btst/stack` from `3.0.0-rc.4` to `3.0.0`
- promote `@btst/codegen` from `0.2.0-rc.4` to `0.2.0`
- pin generated installs to exact `@btst/stack@3.0.0` and public `@btst/better-auth-ui@2.0.0`
- update release-cohort docs and commands from candidate/`@next` references to exact stable versions
- preserve the historical RC2/RC3 compatibility fixtures and evidence

The workspace lockfile is unchanged because these workspace package versions are represented by links, not embedded package-version entries.

## Local release gates

All commands used Node `v22.23.2` and pnpm `10.17.1`.

- `corepack pnpm@10.17.1 install --frozen-lockfile --strict-peer-dependencies`
- `corepack pnpm@10.17.1 build`
- `corepack pnpm@10.17.1 typecheck`
- `corepack pnpm@10.17.1 lint`
- `corepack pnpm@10.17.1 test` — Stack: 87 files / 1,043 tests; Codegen: 11 files / 170 tests
- `corepack pnpm@10.17.1 --dir docs build`
- release metadata assertion — Stack `3.0.0`, Codegen `0.2.0`, tag `v3.0.0`, dist-tag `latest`
- `npm pack --dry-run --json` for both packages — `btst-stack-3.0.0.tgz`, `btst-codegen-0.2.0.tgz`
- `corepack pnpm@10.17.1 test:packed-consumers` — 8/8 harness tests
- packed core consumer: npm and strict pnpm typecheck/build
- packed auth consumer: npm and strict pnpm typecheck/build against public `@btst/better-auth-ui@2.0.0`
- auth graph in both consumers: Better Auth/Core/API-key/passkey `1.6.16`, Utils `0.4.1`, Fetch `1.2.2`, Call `1.3.6`, DB `2.2.3`
- `corepack pnpm@10.17.1 --filter @btst/codegen test:better-auth-ui-fixtures` — untouched Next.js, React Router, and TanStack apps all built and typechecked
- `corepack pnpm@10.17.1 --filter @btst/stack build-registry` — no generated diff
- `corepack pnpm@10.17.1 --filter @btst/stack test-registry` — clean Next.js npm install and production build passed
- audit found no live RC4 or BTST `@next` references; only historical RC2 fixtures remain

Public companion metadata was verified before this change: `@btst/better-auth-ui@2.0.0` is `latest` with npm integrity, shasum, and gitHead metadata.

## Independent review

- Standards: no documented-standard violations; one non-blocking possible Shotgun Surgery judgement call for deliberate synchronized explicit release pins
- Spec: no findings; complete alignment, no scope creep, historical evidence preserved

The PR-triggered Codegen E2E workflow provides the final Playwright/browser matrix for all three frameworks.