### PR TITLE
fix(docs): bypass Stack build on Vercel

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "build:vercel": "next build",
     "dev": "next dev",
     "start": "next start",
     "postinstall": "fumadocs-mdx"

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "pnpm build",
+  "buildCommand": "pnpm build:vercel",
   "headers": [
     {
       "source": "/(.*)",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,9 +1,9 @@
 {
-    "headers": [
-      {
-        "source": "/(.*)",
-        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
-      }
-    ]
-  }
-  
+  "buildCommand": "pnpm build",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- run the docs app's Next.js build directly on Vercel
- bypass Turbo's `^build` edge to the full `@btst/stack` bundle
- expose a docs-specific `build:vercel` script so the deployment seam is explicit

## Why

The v3.0.0 production docs deployment failed with `BUILD_EXCEEDED_MAXIMUM_TIME`. Vercel invalidated its Node 22 cache after the project moved to Node 24, then `turbo run build` cold-built `@btst/stack` and never reached the docs' `next build` before the 45-minute limit.

The Rollup `use client` and mixed-export messages were warnings, not the failure.

## Verification

- clean frozen install with `packages/stack/dist` absent
- `pnpm --dir docs build` under Node 22: passed, 56 pages
- `pnpm --dir docs build:vercel` under Node 24: passed, 56 pages
- standards review: 0 findings
- specification review: 0 findings

Vercel created preview deployments for both branch commits but canceled them at the project-level Ignored Build Step before producing any build logs. Production Git deployments are the remaining remote verification path.
